### PR TITLE
Fix ER Freeze reference in API contracts doc

### DIFF
--- a/docs/API‑Contracts.md
+++ b/docs/API‑Contracts.md
@@ -1,6 +1,7 @@
 API‑Contracts v1.1.3 — Unified (Walking Warehouse + Core Sync)
 Статус: финал для v1 (единый для обоих проектов)
- Основание: выровнено с 00‑Core v1.3; PRD «Ходячий склад» v1.3.2; SRS «Рюкзак» v0.3; PRD Core Sync v1.1.2; SRS Core Sync v1.0.1; ER Freeze v0.6.1
+ Основание: выровнено с 00‑Core v1.3; PRD «Ходячий склад» v1.3.2; SRS «Рюкзак» v0.3; PRD Core Sync v1.1.2; SRS Core Sync v1.0.1; ER Freeze v0.6.4
+ Примечание по совместимости: контракт согласован с ER Freeze v0.6.4 и совместим с инсталляциями, мигрированными с v0.6.1 посредством актуальных SQL‑миграций (`db/migrations`).
 Изменения в v1.1.3 против v1.1.2
 Добавлены единые Pagination & Filtering параметры (limit/offset/page/sort/filter[*]) и правила валидации
 


### PR DESCRIPTION
## Summary
- update the API contracts header to reference ER Freeze v0.6.4 instead of the outdated v0.6.1
- add a compatibility note clarifying support for environments migrated from v0.6.1 via the current SQL migrations

## Testing
- make ci *(fails: No rule to make target 'ci')*

------
https://chatgpt.com/codex/tasks/task_e_68cd2c75d880832abaf8172ce657a07b