### PR TITLE
[docs] clarify API version headers in SRS docs

### DIFF
--- a/docs/SRS — Core Sync 1С: УТ 10.md
+++ b/docs/SRS — Core Sync 1С: УТ 10.md
@@ -151,7 +151,8 @@ FR‑IDEMP‑010. Очереди/ретраи. Экспоненциальный 
 
 8. Внешние интерфейсы (API MW)
 Обязательные заголовки:
- Authorization: Bearer <JWT> • Idempotency-Key: <uuid> • X-Correlation-Id: <uuid> • X-Api-Version: 1.1.3
+ Authorization: Bearer <JWT> • Idempotency-Key: <uuid> • X-Correlation-Id: <uuid> • X-Api-Version: v1
+ Ответ MW возвращает заголовок API-Version: 1.1.3 с текущей минорной версией контракта.
  Кеш‑валидация: ETag/If-None-Match для GET/HEAD; weak‑ETag для списков.
  Идемпотентность PATCH: PATCH‑вызовы считаются идемпотентными и требуют Idempotency-Key.
 НСИ (примеры):

--- a/docs/Software Requirements Specification SRS.md
+++ b/docs/Software Requirements Specification SRS.md
@@ -150,8 +150,9 @@ UI‑требования: чек‑листы по фото, кнопки «З�
 
 
 6. API‑контракты (anchors v1.1.3)
-Общие заголовки (см. 00‑Core §2; API‑Contracts v1.1.3):
- Idempotency-Key: <uuid> (для модифицирующих), X-Correlation-Id: <uuid>, X-Api-Version: 1.1.3, Authorization: Bearer <JWT>.
+ Общие заголовки (см. 00‑Core §2; API‑Contracts v1.1.3):
+ Idempotency-Key: <uuid> (для модифицирующих), X-Correlation-Id: <uuid>, X-Api-Version: v1, Authorization: Bearer <JWT>.
+ Ответ содержит заголовок API-Version: 1.1.3 с текущей минорной версией контракта.
 6.1 POST /api/v1/orders/{id}/ready
 Создать задачу в B24, записать task_id_b24.
  Request


### PR DESCRIPTION
## Summary
- align the mandatory header descriptions in both SRS documents with the 00-Core/API contract requirements by setting `X-Api-Version` to `v1`
- document that the middleware returns the current minor version (`1.1.3`) via the `API-Version` response header

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68cd30224880832a8126338c76f0d068