### PR TITLE
[docs] align instant-order request field name

### DIFF
--- a/docs/Software Requirements Specification SRS.md
+++ b/docs/Software Requirements Specification SRS.md
@@ -184,11 +184,11 @@ GET поддерживает ETag/If-None-Match.
 Примечание: POST /tasks/{id}/status deprecated (Sunset объявлен в API‑Contracts v1.1.3).
 6.4 POST /api/v1/instant-orders
 Создать мгновенный заказ от курьера.
-{
+{ 
   "courier_id": 7,
   "client_phone": "+79991234567",
   "lines": [{"sku":"IP15PM-GLASS","qty":1}],
-  "task_id_b24": 123456,
+  "source_task_id": 123456,
   "currency_code": "RUB"
 }
 


### PR DESCRIPTION
## Summary
- update the POST /api/v1/instant-orders request example so it uses the source_task_id field defined in the API contract

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cdbccead84832a8befad7b8b6154ca