### PR TITLE
Align instant order task id parameter naming

### DIFF
--- a/docs/API‑Contracts.md
+++ b/docs/API‑Contracts.md
@@ -146,7 +146,7 @@ amount, breakdown:{goods, delivery}, currency_code
 POST
 /api/v1/instant-orders
 Создать мгновенный заказ
-courier_id, client_phone, lines[{sku, qty}], source_task_id
+courier_id, client_phone, lines[{sku, qty}], source_task_id (ID задачи B24)
 201 {"id":4321,"draft_order_id_1c":"000123","total":990} + Location
 400, 404, 409, 5xx
 Да

--- a/docs/Software Requirements Specification SRS.md
+++ b/docs/Software Requirements Specification SRS.md
@@ -188,12 +188,14 @@ GET поддерживает ETag/If-None-Match.
   "courier_id": 7,
   "client_phone": "+79991234567",
   "lines": [{"sku":"IP15PM-GLASS","qty":1}],
-  "task_id_b24": 123456,
+  "source_task_id": 123456,
   "currency_code": "RUB"
 }
 
 Response 201
 { "id": 4321, "draft_order_id_1c": "000123", "total": 990 }
+
+Поле `source_task_id` передаёт идентификатор задачи Bitrix24 (`task_id_b24`).
 
 6.5 POST /api/v1/tasks/{id}/photos
 Привязать фото (ID файла B24 Диска) к событию.


### PR DESCRIPTION
## Summary
- clarify that POST /api/v1/instant-orders expects the `source_task_id` field
- add note that the field contains the Bitrix24 task identifier to keep SRS and API contract in sync

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68cdc3d95b40832a82181f4202f498cb