### PR TITLE
docs: align problem+json format reference

### DIFF
--- a/docs/00‑Core — Синхронизация документации.md
+++ b/docs/00‑Core — Синхронизация документации.md
@@ -55,16 +55,21 @@ Content-Type: application/json; charset=utf-8, Accept: application/json.
 }
 
 2.3. Формат ошибок
+Ответы об ошибках возвращаются с `Content-Type: application/problem+json` и соответствуют RFC 7807.
+Минимальный набор полей:
 {
-  "error": {
-    "code": "string",          // machine-readable
-    "message": "string",       // human-readable
-    "correlation_id": "uuid",
-    "details": [ { "field": "...", "issue": "..." } ]
-  }
+  "type": "https://api.example.com/errors/validation",
+  "title": "Validation failed",
+  "status": 400,
+  "detail": "client_phone: must match +7XXXXXXXXXX",
+  "instance": "/api/v1/instant-orders",
+  "code": "validation.format",
+  "errors": [{"field": "client_phone", "reason": "pattern"}]
 }
 
-Коды групп: validation.*, auth.*, conflict.*, not_found.*, rate_limit.*, integration.*, timeout.*.
+`type`, `title`, `status`, `detail`, `instance` и `code` присутствуют всегда; `errors[]` используется для структурированных деталей (валидация полей, ограничения и т. п.). Корреляция ответа обеспечивается заголовком `X-Correlation-Id`.
+
+Таксономия кодов: `validation.*`, `auth.*`, `forbidden`, `not_found.*`, `conflict.duplicate`, `rate_limit.exceeded`, `integration.*`, `timeout.*` (см. Error Code Registry).
 2.4. Пагинация и фильтры
 Параметры limit/offset/page: limit (1..100, по умолчанию 50); offset ≥ 0 или page ≥ 1 (взаимоисключительны); ответы содержат X-Total-Count и Link (rel="next"/"prev").
 

--- a/docs/API‑Contracts.md
+++ b/docs/API‑Contracts.md
@@ -212,6 +212,7 @@ POST
 Без изменений по сравнению с v1.1.2, см. раздел 5 исходника. Дополнение: во всех денежных схемах — currency_code обязателен; для фото допускается heic.
 
 6) Ошибки — application/problem+json
+Базовые требования и формат описаны в 00‑Core §2.3.
 {
   "type": "https://api.example.com/errors/validation",
   "title": "Validation failed",


### PR DESCRIPTION
## Summary
- update 00-Core §2.3 to describe the application/problem+json envelope and refreshed taxonomy
- reference the shared error format from API-Contracts

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68cdc3f64170832a9f816546a6ad6e20