### PR TITLE
docs: align instant order currency field

### DIFF
--- a/docs/API‑Contracts.md
+++ b/docs/API‑Contracts.md
@@ -146,7 +146,7 @@ amount, breakdown:{goods, delivery}, currency_code
 POST
 /api/v1/instant-orders
 Создать мгновенный заказ
-courier_id, client_phone, lines[{sku, qty}], source_task_id (ID задачи B24)
+courier_id, client_phone, lines[{sku, qty}], source_task_id (ID задачи B24), currency_code (ISO-4217)
 201 {"id":4321,"draft_order_id_1c":"000123","total":990} + Location
 400, 404, 409, 5xx
 Да


### PR DESCRIPTION
## Summary
- document that `currency_code` is required when couriers create instant orders
- keep API and SRS examples consistent around the `/api/v1/instant-orders` payload

## Testing
- make ci *(fails: No rule to make target 'ci')*

------
https://chatgpt.com/codex/tasks/task_e_68ce4b600cd8832a8c01559615351ba4