### PR TITLE
docs: add README and contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+# Контрибьютинг
+
+## Бранчинг
+- trunk-based: `main` (protected), фичи — `feat/*`, фиксы — `fix/*`.
+
+## Коммиты
+- Conventional Commits: `feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`.
+- Один PR — одна логическая задача.
+
+## Код-стайл
+- ruff, mypy(strict), black (через ruff format).
+- Перед пушем: `make lint && make typecheck && make test`.
+
+## PR
+- Чек-лист: OpenAPI обновлён? Тесты покрывают изменения? Миграции применяются?

--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# MasterMobile — Middleware & Integrations (FastAPI)
+
+## Что это
+Единый middleware-сервис: интеграция 1С (УТ 10.3/11), Bitrix24 и «Walking Warehouse».
+
+## Быстрый старт (локально)
+```bash
+make init
+make up
+make seed   # по мере появления
+make test
+```
+
+## Архитектура (вкратце)
+- FastAPI (apps/mw/src)
+- Postgres (данные)
+- Redis (кэш/очереди)
+- OpenAPI: ./openapi.yaml
+- CI: .github/workflows/ci.yml
+
+## Полезное
+- Документация: ./docs
+- Контрибьютинг: ./CONTRIBUTING.md
+- Лицензия: ./LICENSE


### PR DESCRIPTION
## Summary
- add a project README with quickstart, architecture, and reference links
- document branching, commit, and review conventions in CONTRIBUTING

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ce6b513600832aa16975218429931c