### PR TITLE
Add Python project configuration and tooling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,35 @@
+.PHONY: init up down logs lint typecheck test fmt openapi run seed
+
+init:
+	python -m venv .venv && . .venv/bin/activate && pip install -U pip && pip install -e .
+	. .venv/bin/activate && pip install -U ruff mypy pytest
+
+up:
+	docker compose up -d --build
+
+down:
+	docker compose down -v
+
+logs:
+	docker compose logs -f app
+
+lint:
+	. .venv/bin/activate && ruff check .
+
+fmt:
+	. .venv/bin/activate && ruff format .
+
+typecheck:
+	. .venv/bin/activate && mypy apps
+
+test:
+	. .venv/bin/activate || true ; pytest
+
+openapi:
+	@echo "OpenAPI: ./openapi.yaml"
+
+run:
+	docker compose up app
+
+seed:
+	@echo "TODO: seed script"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,38 @@
+[project]
+name = "mastermobile"
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = [
+    "fastapi>=0.115",
+    "uvicorn[standard]>=0.30",
+    "pydantic>=2.8",
+    "httpx>=0.27",
+    "sqlalchemy>=2.0",
+    "alembic>=1.13",
+    "psycopg[binary]>=3.2",
+    "redis>=5.0",
+    "python-dotenv>=1.0",
+    "loguru>=0.7",
+    "python-multipart>=0.0.9"
+]
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+lint.select = ["E","F","I","UP","B"]
+lint.ignore = ["E203","E501"]
+format.preview = true
+
+[tool.mypy]
+python_version = "3.11"
+strict = true
+warn_unused_ignores = true
+warn_redundant_casts = true
+disallow_untyped_defs = true
+disallow_incomplete_defs = true
+no_implicit_optional = true
+plugins = []
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-q --maxfail=1"


### PR DESCRIPTION
## Summary
- add `pyproject.toml` with project metadata, runtime dependencies, and tooling settings
- add a Makefile with local environment, linting, testing, and docker helper targets

## Testing
- not run (configuration only)


------
https://chatgpt.com/codex/tasks/task_e_68ce6bd15aa4832aa8cf57dbb544b2aa