### PR TITLE
Add base OpenAPI spec and error catalog

### DIFF
--- a/docs/testing/error_catalog.json
+++ b/docs/testing/error_catalog.json
@@ -1,0 +1,10 @@
+{
+  "errors": {
+    "VALIDATION_ERROR": {"code": "VALIDATION_ERROR", "http": 422, "message": "Invalid input"},
+    "UNAUTHORIZED": {"code": "UNAUTHORIZED", "http": 401, "message": "Unauthorized"},
+    "FORBIDDEN": {"code": "FORBIDDEN", "http": 403, "message": "Forbidden"},
+    "NOT_FOUND": {"code": "NOT_FOUND", "http": 404, "message": "Not found"},
+    "CONFLICT": {"code": "CONFLICT", "http": 409, "message": "Conflict"},
+    "INTERNAL": {"code": "INTERNAL", "http": 500, "message": "Internal server error"}
+  }
+}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,0 +1,30 @@
+openapi: 3.0.3
+info:
+  title: MasterMobile API
+  version: 0.1.0
+servers:
+  - url: http://localhost:8000
+paths:
+  /health:
+    get:
+      tags: [system]
+      summary: Health check
+      operationId: getHealth
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: ok
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+security: []


### PR DESCRIPTION
## Summary
- add a minimal OpenAPI 3.0.3 specification with a health check endpoint
- record the initial placeholder error catalog for testing documentation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ce6c4c5990832a8cb4209c7269061d