### PR TITLE
Add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+          pip install ruff mypy pytest
+
+      - name: Lint
+        run: ruff check .
+
+      - name: Typecheck
+        run: mypy apps
+
+      - name: Tests
+        run: pytest -q


### PR DESCRIPTION
## Summary
- add a GitHub Actions CI pipeline that installs dependencies and runs linting, typing, and tests

## Testing
- not run (workflow only)


------
https://chatgpt.com/codex/tasks/task_e_68ce6cb013d0832a92445739a6c6b309