### PR TITLE
Fix Alembic config path for migration targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,10 +42,10 @@ openapi:
 	@echo "OpenAPI: ./openapi.yaml"
 
 db-upgrade: $(VENV_SENTINEL)
-	$(VENV_BIN)/alembic -c apps/mw/migrations/alembic.ini upgrade head
+	$(VENV_BIN)/alembic -c alembic.ini upgrade head
 
 db-downgrade: $(VENV_SENTINEL)
-	$(VENV_BIN)/alembic -c apps/mw/migrations/alembic.ini downgrade -1
+	$(VENV_BIN)/alembic -c alembic.ini downgrade -1
 
 run:
 	docker compose up app

--- a/docs/runbooks/local_dev.md
+++ b/docs/runbooks/local_dev.md
@@ -1,5 +1,8 @@
 # Локальная разработка
 1) `make init` — venv и базовые инструменты
 2) `make up` — поднимает db/redis/app
-3) `make test` — прогоним тесты
-4) Точки входа: `apps/mw/src/app.py` (uvicorn)
+3) `make db-upgrade` — применяет миграции через корневой `./alembic.ini`
+4) `make test` — прогоним тесты
+5) Точки входа: `apps/mw/src/app.py` (uvicorn)
+
+> Для ручного запуска Alembic используйте `.venv/bin/alembic -c ./alembic.ini upgrade head`.


### PR DESCRIPTION
## Summary
- point the db-upgrade and db-downgrade make targets to the real alembic.ini in the repo root
- document the working migration command in the local development runbook, including the correct make target

## Testing
- make db-upgrade *(fails: missing Postgres service in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce82661544832a81397ae71cedf8a5