### PR TITLE
feat: align migrations with ER design

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,6 @@ RUN apt-get update \
 COPY pyproject.toml README.md ./
 COPY apps ./apps
 COPY httpx ./httpx
-COPY alembic.ini ./
 COPY openapi.yaml ./
 
 RUN pip install --no-cache-dir --upgrade pip \

--- a/Makefile
+++ b/Makefile
@@ -42,10 +42,10 @@ openapi:
 	@echo "OpenAPI: ./openapi.yaml"
 
 db-upgrade: $(VENV_SENTINEL)
-	$(VENV_BIN)/alembic -c alembic.ini upgrade head
+	$(VENV_BIN)/alembic -c apps/mw/migrations/alembic.ini upgrade head
 
 db-downgrade: $(VENV_SENTINEL)
-	$(VENV_BIN)/alembic -c alembic.ini downgrade -1
+	$(VENV_BIN)/alembic -c apps/mw/migrations/alembic.ini downgrade -1
 
 run:
 	docker compose up app

--- a/apps/mw/migrations/alembic.ini
+++ b/apps/mw/migrations/alembic.ini
@@ -1,5 +1,5 @@
 [alembic]
-script_location = apps/mw/migrations
+script_location = .
 sqlalchemy.url = postgresql+psycopg://postgres:postgres@db:5432/mastermobile
 
 [loggers]

--- a/docs/runbooks/local_dev.md
+++ b/docs/runbooks/local_dev.md
@@ -3,8 +3,8 @@
 1) `make init` — venv и базовые инструменты
 2) `docker compose up -d db redis` — поднимает только Postgres и Redis (по необходимости)
 3) `make up` — собирает образ приложения и стартует app/db/redis
-4) `make db-upgrade` — применяет миграции через корневой `./alembic.ini`
+4) `make db-upgrade` — применяет миграции через `./apps/mw/migrations/alembic.ini`
 5) `make test` — прогоним тесты
 6) Точки входа: `apps/mw/src/app.py` (uvicorn)
 
-> Для ручного запуска Alembic используйте `.venv/bin/alembic -c ./alembic.ini upgrade head`.
+> Для ручного запуска Alembic используйте `.venv/bin/alembic -c ./apps/mw/migrations/alembic.ini upgrade head`.


### PR DESCRIPTION
## Summary
- align the initial Alembic migration with the documented ERD (UUID keys, relationships, and constraints)
- move Alembic configuration into `apps/mw/migrations` and update tooling/docs to use the new path

## Testing
- make lint *(fails: existing Ruff violations in untouched modules)*
- make typecheck
- make test

------
https://chatgpt.com/codex/tasks/task_e_68cea077d408832a8b1bc71b6562ec36