### PR TITLE
docs: align return schemas with database

### DIFF
--- a/docs/API‑Contracts.md
+++ b/docs/API‑Contracts.md
@@ -186,7 +186,7 @@ POST
 POST
 /api/v1/returns
 Инициировать возврат (return_ready)
-{ source:widget, courier_id, order_id_1c?, items:[{sku, qty, quality:new|defect, reason_code, reason_note?, photos:[b24_file_id], imei?, serial?}] }
+{ source:widget, courier_id, order_id_1c?, items:[{sku, qty, quality:new|defect, reason_id? (UUID), reason_note?, photos:[b24_file_id], imei?, serial?}] }
 201 {"return_id":501} + Location
 400, 401, 404, 409
 Да

--- a/docs/Software Requirements Specification SRS.md
+++ b/docs/Software Requirements Specification SRS.md
@@ -216,7 +216,7 @@ POST /api/v1/returns — инициировать возврат (return_ready):
   "source": "widget",
   "courier_id": 7,
   "order_id_1c": "000123",
-  "items": [{"sku":"IP15PM-GLASS","qty":1,"quality":"defect","reason_code":"cracked","photos":["disk:123"],"imei":null,"serial":null}]
+  "items": [{"sku":"IP15PM-GLASS","qty":1,"quality":"defect","reason_id":"3fa85f64-5717-4562-b3fc-2c963f66afa6","photos":["disk:123"],"imei":null,"serial":null}]
 }
 
 POST /api/v1/returns/{id}/reject — отклонить «брак не подтвердился»:

--- a/docs/integrations/1c_mapping.md
+++ b/docs/integrations/1c_mapping.md
@@ -19,7 +19,7 @@
 | Реализация товаров и услуг | `sales.shipments` | `document_number`, `document_date`, `customer_id`, `total_amount`, `currency_code`, `lines[]` | Каждая строка содержит `sku`, `qty`, `price`, `vat_rate`; суммы пересчитываются в RUB по курсу ЦБ |
 | Поступление товаров | `inventory.incoming` | `supplier_id`, `contract_id`, `planned_receipt_at`, `lines[]` | После приёма создаётся задача в walking warehouse, статус `pending_quality_check` |
 | Перемещение товаров | `inventory.transfers` | `source_warehouse_id`, `target_warehouse_id`, `reason_code`, `lines[]` | Поддерживаются межфилиальные перемещения; дополнительные уведомления для `reason_code = interbranch` |
-| Возвраты от клиентов | `returns.requests` | `source_system`, `order_id`, `items[]`, `status`, `compensation_amount` | Синхронизируется с API `/api/v1/returns`; Idempotency-Key формируется как SHA256 от `document_number` |
+| Возвраты от клиентов | `returns.requests` | `source_system`, `order_id`, `status` (`return_ready`\|`accepted`\|`return_rejected`), `items[]` (`quality` = `new`\|`defect`, `reason_id`?) | Синхронизируется с API `/api/v1/returns`; Idempotency-Key формируется как SHA256 от `document_number`; `reason_id` хранится как UUID, может отсутствовать |
 | Денежные документы (ПКО/РКО) | `finance.cash_documents` | `document_number`, `document_date`, `amount`, `cashier_id`, `operation_type` | Используется для сверки наличных и задач курьеров |
 
 ## Статусы и справочники

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -363,11 +363,10 @@ components:
           type: string
           description: Current status of the return.
           enum:
-            - pending
+            - return_ready
             - accepted
-            - rejected
-            - cancelled
-          example: pending
+            - return_rejected
+          example: return_ready
         source:
           type: string
           description: Channel that initiated the return.
@@ -415,7 +414,6 @@ components:
               - sku
               - qty
               - quality
-              - reason_code
             properties:
               line_id:
                 type: string
@@ -436,12 +434,13 @@ components:
                 enum:
                   - new
                   - defect
-                  - unknown
                 example: defect
-              reason_code:
+              reason_id:
                 type: string
-                description: Machine-readable reason code.
-                example: damaged_package
+                format: uuid
+                nullable: true
+                description: Identifier of the predefined reason for the return when supplied.
+                example: 3fa85f64-5717-4562-b3fc-2c963f66afa6
               reason_note:
                 type: string
                 nullable: true
@@ -498,7 +497,6 @@ components:
               - sku
               - qty
               - quality
-              - reason_code
             properties:
               sku:
                 type: string
@@ -515,12 +513,12 @@ components:
                 enum:
                   - new
                   - defect
-                  - unknown
                 example: defect
-              reason_code:
+              reason_id:
                 type: string
-                description: Machine-readable reason code.
-                example: damaged_package
+                format: uuid
+                description: Optional reference to the predefined reason for the return.
+                example: 3fa85f64-5717-4562-b3fc-2c963f66afa6
               reason_note:
                 type: string
                 nullable: true


### PR DESCRIPTION
## Summary
- update the OpenAPI return schemas to use `return_ready`/`return_rejected`, remove the `unknown` quality value, and expose optional UUID `reason_id`
- sync the 1C integration mapping, API contract, and SRS examples with the database-backed vocabulary

## Testing
- make lint
- make typecheck
- make test

------
https://chatgpt.com/codex/tasks/task_e_68cee4ba7d78832a9aba3f4a056283b9