### PR TITLE
feat: document returns status filter

### DIFF
--- a/docs/API‑Contracts.md
+++ b/docs/API‑Contracts.md
@@ -183,6 +183,13 @@ POST
 Успех
 Ошибки
 Идемп.
+GET
+/api/v1/returns
+Список возвратов
+Параметры: status? (return_ready|accepted|return_rejected), page?, page_size?
+200 { items:[Return], page, page_size, total_items, total_pages, has_next }
+400, 401
+Да
 POST
 /api/v1/returns
 Инициировать возврат (return_ready)

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -74,6 +74,7 @@ paths:
         - $ref: '#/components/parameters/XRequestId'
         - $ref: '#/components/parameters/Page'
         - $ref: '#/components/parameters/PageSize'
+        - $ref: '#/components/parameters/ReturnStatus'
       responses:
         '200':
           description: A paginated collection of returns.
@@ -361,13 +362,12 @@ components:
           example: ret_501
         status:
           type: string
-          description: Current status of the return.
+          description: Current status of the return. See «00‑Core — Синхронизация документации», §3 for canonical values.
           enum:
-            - pending
+            - return_ready
             - accepted
-            - rejected
-            - cancelled
-          example: pending
+            - return_rejected
+          example: return_ready
         source:
           type: string
           description: Channel that initiated the return.
@@ -620,6 +620,17 @@ components:
       description: Identifier of the return.
       schema:
         type: string
+    ReturnStatus:
+      name: status
+      in: query
+      required: false
+      description: Filter returns by workflow status. Values correspond to Status-Dictionary v1.
+      schema:
+        type: string
+        enum:
+          - return_ready
+          - accepted
+          - return_rejected
   headers:
     XRequestId:
       description: Identifier correlating the request with logs and traces.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,8 @@ dependencies = [
 dev = [
     "mypy>=1.11",
     "pytest>=8.2",
-    "ruff>=0.5"
+    "ruff>=0.5",
+    "pyyaml>=6.0"
 ]
 
 [tool.setuptools]

--- a/tests/test_openapi_returns.py
+++ b/tests/test_openapi_returns.py
@@ -1,0 +1,75 @@
+"""Contract-level tests guarding the returns listing contract."""
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from apps.mw.src.db.models import ReturnStatus
+
+
+def _load_openapi() -> dict[str, Any]:
+    spec_path = Path("openapi.yaml")
+    loaded = yaml.safe_load(spec_path.read_text())
+    assert isinstance(loaded, dict)
+    return loaded
+
+
+def test_returns_status_parameter_matches_domain_enum() -> None:
+    """Ensure the query parameter reuses the canonical return status values."""
+
+    spec = _load_openapi()
+    components = spec["components"]
+    assert isinstance(components, dict)
+    parameters = components["parameters"]
+    assert isinstance(parameters, dict)
+    status_param = parameters["ReturnStatus"]
+    assert isinstance(status_param, dict)
+    schema = status_param["schema"]
+    assert isinstance(schema, dict)
+    param_values = schema["enum"]
+    assert isinstance(param_values, list)
+
+    expected_values = sorted(status.value for status in ReturnStatus)
+
+    assert sorted(param_values) == expected_values
+
+
+def test_returns_status_parameter_is_used_by_list_endpoint() -> None:
+    """The list endpoint must expose the reusable status filter."""
+
+    spec = _load_openapi()
+    paths = spec["paths"]
+    assert isinstance(paths, dict)
+    returns_path = paths["/api/v1/returns"]
+    assert isinstance(returns_path, dict)
+    get_operation = returns_path["get"]
+    assert isinstance(get_operation, dict)
+    parameters = get_operation["parameters"]
+    assert isinstance(parameters, list)
+    assert any(
+        isinstance(parameter, dict) and parameter.get("$ref") == "#/components/parameters/ReturnStatus"
+        for parameter in parameters
+    ), "GET /api/v1/returns must reference the shared ReturnStatus query parameter"
+
+
+def test_returns_status_schema_matches_query_parameter() -> None:
+    """The response payload must follow the same enum as the query filter."""
+
+    spec = _load_openapi()
+    components = spec["components"]
+    assert isinstance(components, dict)
+    schemas = components["schemas"]
+    assert isinstance(schemas, dict)
+    return_schema = schemas["Return"]
+    assert isinstance(return_schema, dict)
+    properties = return_schema["properties"]
+    assert isinstance(properties, dict)
+    status_property = properties["status"]
+    assert isinstance(status_property, dict)
+    schema_values = status_property["enum"]
+    assert isinstance(schema_values, list)
+
+    expected_values = sorted(status.value for status in ReturnStatus)
+
+    assert sorted(schema_values) == expected_values


### PR DESCRIPTION
## Summary
- add a reusable `ReturnStatus` query parameter to the OpenAPI contract and align the return status enum with the canonical values
- describe the status filter for `GET /api/v1/returns` in the API contracts document
- add contract tests that ensure the OpenAPI filter matches the domain enum

## Testing
- make lint
- make typecheck
- make test

------
https://chatgpt.com/codex/tasks/task_e_68cee4bbf170832ab703ee26d293d54b