### PR TITLE
fix: source app environment from env files

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,18 +7,9 @@ services:
     image: mastermobile-app:local
     command: >-
       uvicorn apps.mw.src.app:app --host 0.0.0.0 --port ${APP_PORT:-8000} --reload
-    environment:
-      APP_ENV: ${APP_ENV:-local}
-      APP_HOST: ${APP_HOST:-0.0.0.0}
-      APP_PORT: ${APP_PORT:-8000}
-      LOG_LEVEL: ${LOG_LEVEL:-INFO}
-      DB_HOST: ${DB_HOST:-db}
-      DB_PORT: ${DB_PORT:-5432}
-      DB_USER: ${DB_USER:-postgres}
-      DB_PASSWORD: ${DB_PASSWORD:-postgres}
-      DB_NAME: ${DB_NAME:-mastermobile}
-      REDIS_HOST: ${REDIS_HOST:-redis}
-      REDIS_PORT: ${REDIS_PORT:-6379}
+    env_file:
+      - .env
+      - .env.example
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
## Summary
- load the app service environment from .env and .env.example using compose env_file support
- drop the redundant inline environment entries now provided by the env files

## Testing
- make up *(fails: docker client not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cee4d313f4832ab6b21f0b6d4d4bc6