### PR TITLE
docs: add architecture quick link

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@
 - CI: .github/workflows/ci.yml
 
 ## Полезное
+- Архитектура: [docs/architecture/overview.md](docs/architecture/overview.md)
 - Документация: ./docs
 - Контрибьютинг: ./CONTRIBUTING.md
 - Лицензия: ./LICENSE


### PR DESCRIPTION
## Summary
- add an explicit quick link to the architecture overview document in the README

## Testing
- not run (docs-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cee4d40960832a9c9314f1fe2bc02e