### PR TITLE
fix: align return models with migrations

### DIFF
--- a/tests/test_db_models_returns.py
+++ b/tests/test_db_models_returns.py
@@ -1,0 +1,75 @@
+"""Integration tests for ORM mappings of returns tables."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from uuid import uuid4
+
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import Session
+
+from apps.mw.src.db.models import (
+    Base,
+    Return,
+    ReturnLine,
+    ReturnLineQuality,
+    ReturnSource,
+    ReturnStatus,
+)
+
+
+def test_return_roundtrip_matches_schema() -> None:
+    """Persist and load return with lines to ensure UUID/relationships match migration."""
+
+    engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+    Base.metadata.create_all(engine, tables=[Return.__table__, ReturnLine.__table__])
+
+    return_id = uuid4()
+    reason_id = uuid4()
+
+    with Session(engine) as session:
+        return_obj = Return(
+            return_id=return_id,
+            status=ReturnStatus.RETURN_READY,
+            source=ReturnSource.WAREHOUSE,
+            courier_id="courier-42",
+            order_id_1c="order-1c",
+            comment="Quality check",
+        )
+        return_obj.lines.append(
+            ReturnLine(
+                id=1,
+                line_id="line-1",
+                sku="sku-1",
+                qty=Decimal("2.500"),
+                quality=ReturnLineQuality.NEW,
+                reason_id=reason_id,
+                reason_note="Packaging damaged",
+                photos=None,
+                imei="123456789012345",
+                serial="SN123456789",
+            )
+        )
+
+        session.add(return_obj)
+        session.commit()
+        session.expunge_all()
+
+        loaded = session.scalars(
+            select(Return).where(Return.return_id == return_id)
+        ).one()
+
+        assert loaded.return_id == return_id
+        assert loaded.lines, "Return should contain associated lines"
+
+        line = loaded.lines[0]
+        assert line.return_id == return_id
+        assert line.line_id == "line-1"
+        assert line.qty == Decimal("2.500")
+        assert isinstance(line.qty, Decimal)
+        assert line.quality is ReturnLineQuality.NEW
+        assert line.reason_id == reason_id
+        assert line.photos is None
+        assert line.serial == "SN123456789"
+
+    engine.dispose()


### PR DESCRIPTION
## Summary
- convert the returns primary key to UUID and align column definitions with the Alembic migration
- restore the return_lines schema (UUID FKs, numeric qty, optional photos) and share a JSON-compatible type for SQLite
- add an ORM round-trip test that persists and loads a return with lines to validate the mappings

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68cef7155bc4832a8dab15c25eb31386