### PR TITLE
feat: sync IntegrationLog ORM with migration

### DIFF
--- a/apps/mw/src/db/models.py
+++ b/apps/mw/src/db/models.py
@@ -19,8 +19,9 @@ from sqlalchemy import (
 from sqlalchemy import (
     Enum as SqlEnum,
 )
-from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
+
+from .types import JSONBType
 
 
 class Base(DeclarativeBase):
@@ -120,7 +121,7 @@ class ReturnLine(Base):
     reason_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
     reason_note: Mapped[str | None] = mapped_column(Text, nullable=True)
     photos: Mapped[list[str]] = mapped_column(
-        JSONB,
+        JSONBType(),
         nullable=False,
         default=list,
         server_default=text("'[]'::jsonb"),
@@ -146,17 +147,16 @@ class IntegrationLog(Base):
         SqlEnum(IntegrationDirection, name="integration_direction"),
         nullable=False,
     )
-    system: Mapped[str] = mapped_column(String(64), nullable=False)
+    external_system: Mapped[str] = mapped_column(String(32), nullable=False)
     endpoint: Mapped[str] = mapped_column(String(255), nullable=False)
-    status_code: Mapped[int] = mapped_column(Integer, nullable=False)
-    correlation_id: Mapped[str | None] = mapped_column(String(128), nullable=True)
-    request: Mapped[dict[str, Any]] = mapped_column(
-        JSONB,
-        nullable=False,
-        default=dict,
-        server_default=text("'{}'::jsonb"),
+    status: Mapped[str] = mapped_column(String(32), nullable=False)
+    status_code: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    correlation_id: Mapped[str | None] = mapped_column(Text, nullable=True)
+    resource_ref: Mapped[str | None] = mapped_column(Text, nullable=True)
+    request: Mapped[dict[str, Any] | None] = mapped_column(
+        JSONBType(),
+        nullable=True,
     )
-    response: Mapped[dict[str, Any] | None] = mapped_column(JSONB, nullable=True)
-    error: Mapped[str | None] = mapped_column(Text, nullable=True)
-    duration_ms: Mapped[int | None] = mapped_column(Integer, nullable=True)
-    retry_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0, server_default=text("0"))
+    response: Mapped[dict[str, Any] | None] = mapped_column(JSONBType(), nullable=True)
+    error_code: Mapped[str | None] = mapped_column(Text, nullable=True)
+    retry_count: Mapped[int | None] = mapped_column(Integer, nullable=True, default=None)

--- a/apps/mw/src/db/types.py
+++ b/apps/mw/src/db/types.py
@@ -1,0 +1,21 @@
+"""Database type helpers for MasterMobile middleware."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.types import JSON, TypeDecorator
+
+
+class JSONBType(TypeDecorator[Any]):
+    """JSONB-compatible type that falls back to JSON on SQLite."""
+
+    impl = JSONB
+    cache_ok = True
+
+    def load_dialect_impl(self, dialect):  # type: ignore[override]
+        if dialect.name == "sqlite":
+            return dialect.type_descriptor(JSON())
+        return dialect.type_descriptor(JSONB())
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,9 +2,11 @@ import asyncio
 import json
 import multiprocessing
 import socket
+import sys
 import time
 from collections.abc import Iterator
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
 
 import pytest
 
@@ -12,6 +14,8 @@ try:
     import uvicorn
 except ImportError:  # pragma: no cover - optional dependency
     uvicorn = None  # type: ignore[assignment]
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from apps.mw.src.health import HEALTH_PAYLOAD
 

--- a/tests/test_integration_log_model.py
+++ b/tests/test_integration_log_model.py
@@ -1,0 +1,52 @@
+"""IntegrationLog ORM synchronisation tests."""
+
+from __future__ import annotations
+
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import Session
+from sqlalchemy.pool import StaticPool
+
+from apps.mw.src.db.models import Base, IntegrationDirection, IntegrationLog
+
+
+def test_integration_log_roundtrip() -> None:
+    """The IntegrationLog ORM model matches the database schema."""
+
+    engine = create_engine(
+        "sqlite+pysqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine, tables=[IntegrationLog.__table__])
+
+    log_entry = IntegrationLog(
+        direction=IntegrationDirection.OUTBOUND,
+        external_system="b24",
+        endpoint="/sync/orders",
+        status="error",
+        status_code=None,
+        correlation_id=None,
+        resource_ref="order-42",
+        request={"payload": True},
+        response={"result": "error"},
+        error_code="E_CONN_TIMEOUT",
+        retry_count=None,
+    )
+
+    with Session(engine) as session:
+        session.add(log_entry)
+        session.commit()
+
+        stored_log = session.scalar(
+            select(IntegrationLog).where(IntegrationLog.id == log_entry.id)
+        )
+
+    assert stored_log is not None
+    assert stored_log.external_system == "b24"
+    assert stored_log.status == "error"
+    assert stored_log.status_code is None
+    assert stored_log.request == {"payload": True}
+    assert stored_log.response == {"result": "error"}
+    assert stored_log.error_code == "E_CONN_TIMEOUT"
+    assert stored_log.retry_count is None
+    assert stored_log.resource_ref == "order-42"


### PR DESCRIPTION
## Summary
- align `IntegrationLog` ORM model with the initial migration by renaming `system` to `external_system`, adding missing fields, and dropping unused ones
- introduce a JSONB compatibility helper so the model can be instantiated against SQLite in tests
- ensure pytest can import the application package and add an ORM round-trip test for `IntegrationLog`

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cef71d760c832aa1d2d694faeaeffc