### PR TITLE
docs: align api contracts references

### DIFF
--- a/docs/00‑Core — Синхронизация документации.md
+++ b/docs/00‑Core — Синхронизация документации.md
@@ -156,7 +156,7 @@ Status‑Dictionary v1
  - CANCELLED — заменён на REFUSED; в status_dict помечается deprecated=true, новые интеграции его не используют.
  - NON_CASH_CONFIRMED — сверка безналичных оплат закрывается статусом DONE; значение выводится из справочника.
  - CLOSED — финальный статус объединён с DONE, исторические записи мигрируют на новый код.
- Статусы и переходы согласованы с владельцами API‑Contracts v1.1.3 (docs/API‑Contracts.md).
+Статусы и переходы согласованы с владельцами API‑Contracts v1.0.0 (docs/API‑Contracts.md).
 3.2. Instant Orders (быстрые продажи курьера)
  DRAFT → PENDING_APPROVAL → APPROVED → (DELIVERED|CANCELLED)
  Отказы: REJECTED, эскалация тайм‑аута: TIMEOUT_ESCALATED.


### PR DESCRIPTION
## Summary
- update the 00-Core synchronization document to reference API-Contracts v1.0.0 instead of the outdated v1.1.3 mention

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cefe4856cc832a844f3891a42c721c