### PR TITLE
feat: add system ping endpoint

### DIFF
--- a/apps/mw/src/app.py
+++ b/apps/mw/src/app.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI
 
-from .health import get_health_payload
+from .health import get_health_payload, get_ping_payload
 
 app = FastAPI(title="MasterMobile MW")
 
@@ -9,3 +9,9 @@ app = FastAPI(title="MasterMobile MW")
 async def health() -> dict[str, str]:
     """Simple health-check endpoint used by smoke tests."""
     return get_health_payload()
+
+
+@app.get("/api/v1/system/ping")
+async def system_ping() -> dict[str, str]:
+    """Return the middleware status along with a UTC timestamp."""
+    return get_ping_payload()

--- a/apps/mw/src/health.py
+++ b/apps/mw/src/health.py
@@ -1,8 +1,35 @@
 """Domain-level helpers for health-check responses."""
 
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
 HEALTH_PAYLOAD: dict[str, str] = {"status": "ok"}
+PING_STATUS = "pong"
+PING_SERVICE_IDENTIFIER = "master-mobile-middleware"
 
 
 def get_health_payload() -> dict[str, str]:
     """Return the canonical payload for the health endpoint."""
     return HEALTH_PAYLOAD
+
+
+def get_ping_payload(*, service: str | None = PING_SERVICE_IDENTIFIER) -> dict[str, str]:
+    """Return the canonical payload for the ping endpoint."""
+    payload: dict[str, str] = {
+        "status": PING_STATUS,
+        "timestamp": _current_utc_timestamp(),
+    }
+    if service:
+        payload["service"] = service
+    return payload
+
+
+def _current_utc_timestamp() -> str:
+    """Return the current UTC timestamp in ISO 8601 format."""
+    return (
+        datetime.now(UTC)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ try:
 except ImportError:  # pragma: no cover - optional dependency
     uvicorn = None  # type: ignore[assignment]
 
-from apps.mw.src.health import HEALTH_PAYLOAD
+from apps.mw.src.health import HEALTH_PAYLOAD, get_ping_payload
 
 _HOST = "127.0.0.1"
 _PORT = 8000
@@ -25,6 +25,14 @@ class _HealthHandler(BaseHTTPRequestHandler):
     def do_GET(self) -> None:  # noqa: N802 (BaseHTTPRequestHandler API)
         if self.path == "/health":
             body = json.dumps(HEALTH_PAYLOAD).encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+        elif self.path == "/api/v1/system/ping":
+            payload = get_ping_payload()
+            body = json.dumps(payload).encode("utf-8")
             self.send_response(200)
             self.send_header("Content-Type", "application/json")
             self.send_header("Content-Length", str(len(body)))

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,3 +1,5 @@
+from datetime import UTC, datetime, timedelta
+
 import pytest
 
 import httpx
@@ -11,3 +13,27 @@ async def test_health() -> None:
         response = await client.get("/health")
     assert response.status_code == 200
     assert response.json().get("status") == "ok"
+
+
+@pytest.mark.asyncio
+async def test_system_ping() -> None:
+    async with httpx.AsyncClient(base_url=BASE_URL) as client:
+        response = await client.get("/api/v1/system/ping")
+
+    assert response.status_code == 200
+
+    payload = response.json()
+    assert payload["status"] == "pong"
+
+    timestamp = payload["timestamp"]
+    parsed_timestamp = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+    assert parsed_timestamp.tzinfo is not None
+    assert parsed_timestamp.tzinfo.utcoffset(parsed_timestamp) == timedelta(0)
+
+    now = datetime.now(UTC)
+    delta = now - parsed_timestamp
+    assert timedelta(0) <= delta < timedelta(seconds=5)
+
+    if "service" in payload:
+        assert isinstance(payload["service"], str)
+        assert payload["service"].strip()


### PR DESCRIPTION
## Summary
- register the `/api/v1/system/ping` route in the FastAPI app
- add a reusable helper that builds the ping payload with a UTC timestamp
- cover the new endpoint in smoke tests and update the fallback server handler

## Testing
- make lint
- make typecheck
- make test

------
https://chatgpt.com/codex/tasks/task_e_68d002c12484832a920efcdc24be6433