### PR TITLE
feat: add settings module and db session factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 | `APP_ENV`       | `local`                | Режим работы приложения             |
 | `APP_HOST`      | `0.0.0.0`              | Адрес, на котором слушает uvicorn   |
 | `APP_PORT`      | `8000`                 | Порт приложения и проброс наружу    |
+| `DATABASE_URL`  | —                      | Полный DSN Postgres (перекрывает настройки ниже) |
 | `DB_HOST`       | `db`                   | Хост Postgres внутри docker-compose |
 | `DB_PORT`       | `5432`                 | Порт Postgres                       |
 | `DB_USER`       | `postgres`             | Имя пользователя БД                 |

--- a/apps/mw/migrations/env.py
+++ b/apps/mw/migrations/env.py
@@ -1,43 +1,28 @@
 """Alembic environment configuration for MasterMobile."""
 from __future__ import annotations
 
-import os
 from logging.config import fileConfig
 
 from alembic import context
 from sqlalchemy import engine_from_config, pool
+
+from apps.mw.src.config import get_settings
+from apps.mw.src.db import Base
 
 config = context.config
 
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)
 
+settings = get_settings()
+config.set_main_option("sqlalchemy.url", settings.sqlalchemy_database_uri)
 
-def _database_url() -> str:
-    """Construct a SQLAlchemy URL based on environment variables."""
-    url = os.getenv("DATABASE_URL")
-    if url:
-        return url
-
-    user = os.getenv("DB_USER", "postgres")
-    password = os.getenv("DB_PASSWORD", "postgres")
-    host = os.getenv("DB_HOST", "db")
-    port = os.getenv("DB_PORT", "5432")
-    name = os.getenv("DB_NAME", "mastermobile")
-    return f"postgresql+psycopg://{user}:{password}@{host}:{port}/{name}"
-
-
-def _configure_url() -> None:
-    config.set_main_option("sqlalchemy.url", _database_url())
-
-
-_configure_url()
-
-target_metadata = None
+target_metadata = Base.metadata
 
 
 def run_migrations_offline() -> None:
     """Run migrations in 'offline' mode."""
+
     url = config.get_main_option("sqlalchemy.url")
     context.configure(
         url=url,
@@ -53,6 +38,7 @@ def run_migrations_offline() -> None:
 
 def run_migrations_online() -> None:
     """Run migrations in 'online' mode."""
+
     connectable = engine_from_config(
         config.get_section(config.config_ini_section, {}),
         prefix="sqlalchemy.",

--- a/apps/mw/src/config/__init__.py
+++ b/apps/mw/src/config/__init__.py
@@ -1,2 +1,5 @@
-"""Пакет конфигурационных объектов middleware."""
-# пусто, для будущих конфигов
+"""Configuration utilities for the middleware."""
+
+from .settings import Settings, get_settings
+
+__all__ = ["Settings", "get_settings"]

--- a/apps/mw/src/config/settings.py
+++ b/apps/mw/src/config/settings.py
@@ -1,0 +1,61 @@
+"""Application settings loaded from environment and .env files."""
+from __future__ import annotations
+
+from functools import lru_cache
+
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    """Strongly-typed application configuration."""
+
+    model_config = SettingsConfigDict(
+        env_file=(".env", ".env.example"),
+        env_file_encoding="utf-8",
+        extra="ignore",
+        populate_by_name=True,
+    )
+
+    app_env: str = Field(default="local", alias="APP_ENV")
+    app_host: str = Field(default="0.0.0.0", alias="APP_HOST")
+    app_port: int = Field(default=8000, alias="APP_PORT")
+
+    db_host: str = Field(default="db", alias="DB_HOST")
+    db_port: int = Field(default=5432, alias="DB_PORT")
+    db_user: str = Field(default="postgres", alias="DB_USER")
+    db_password: str = Field(default="postgres", alias="DB_PASSWORD")
+    db_name: str = Field(default="mastermobile", alias="DB_NAME")
+    database_url: str | None = Field(default=None, alias="DATABASE_URL")
+
+    redis_host: str = Field(default="redis", alias="REDIS_HOST")
+    redis_port: int = Field(default=6379, alias="REDIS_PORT")
+
+    log_level: str = Field(default="INFO", alias="LOG_LEVEL")
+    jwt_secret: str = Field(default="changeme", alias="JWT_SECRET")
+    jwt_issuer: str = Field(default="mastermobile", alias="JWT_ISSUER")
+    cors_origins: str = Field(default="http://localhost:3000", alias="CORS_ORIGINS")
+    max_page_size: int = Field(default=100, alias="MAX_PAGE_SIZE")
+    request_timeout_s: int = Field(default=30, alias="REQUEST_TIMEOUT_S")
+    enable_tracing: bool = Field(default=False, alias="ENABLE_TRACING")
+    pii_masking_enabled: bool = Field(default=False, alias="PII_MASKING_ENABLED")
+    disk_encryption_flag: bool = Field(default=False, alias="DISK_ENCRYPTION_FLAG")
+
+    @property
+    def sqlalchemy_database_uri(self) -> str:
+        """Return a SQLAlchemy-compatible database URL."""
+
+        if self.database_url:
+            return self.database_url
+
+        return (
+            f"postgresql+psycopg://{self.db_user}:{self.db_password}"
+            f"@{self.db_host}:{self.db_port}/{self.db_name}"
+        )
+
+
+@lru_cache
+def get_settings() -> Settings:
+    """Return a cached settings instance."""
+
+    return Settings()

--- a/apps/mw/src/db/session.py
+++ b/apps/mw/src/db/session.py
@@ -1,0 +1,43 @@
+"""Database session management utilities."""
+from __future__ import annotations
+
+from collections.abc import Generator
+
+from sqlalchemy import create_engine
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from apps.mw.src.config import get_settings
+
+_settings = get_settings()
+
+engine: Engine = create_engine(
+    _settings.sqlalchemy_database_uri,
+    future=True,
+    pool_pre_ping=True,
+)
+
+SessionLocal: sessionmaker[Session] = sessionmaker(
+    bind=engine,
+    autoflush=False,
+    expire_on_commit=False,
+    class_=Session,
+)
+
+
+def configure_engine(bind: Engine) -> None:
+    """Rebind the session factory to a different engine (used for tests)."""
+
+    global engine
+    engine = bind
+    SessionLocal.configure(bind=bind)
+
+
+def get_session() -> Generator[Session, None, None]:
+    """FastAPI dependency that yields a database session."""
+
+    session = SessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "fastapi>=0.115",
     "uvicorn[standard]>=0.30",
     "pydantic>=2.8",
+    "pydantic-settings>=2.3",
     "httpx>=0.27",
     "sqlalchemy>=2.0",
     "alembic>=1.13",

--- a/tests/test_db_session.py
+++ b/tests/test_db_session.py
@@ -1,0 +1,57 @@
+"""Tests for database session factory configuration."""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+
+from sqlalchemy import create_engine, text
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import Session
+
+from apps.mw.src.app import app
+from apps.mw.src.db import Base
+from apps.mw.src.db.session import configure_engine, get_session
+from apps.mw.src.db.session import engine as default_engine
+
+
+def test_get_session_provides_in_memory_sqlite_session() -> None:
+    """`get_session` should yield a working SQLite session for tests."""
+
+    sqlite_engine: Engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+    Base.metadata.create_all(sqlite_engine)
+
+    session_gen: Generator[Session, None, None] | None = None
+    override_gen: Generator[Session, None, None] | None = None
+
+    try:
+        configure_engine(sqlite_engine)
+
+        session_gen = get_session()
+        session = next(session_gen)
+
+        result = session.execute(text("SELECT 1")).scalar_one()
+        assert result == 1
+        assert str(session.get_bind().url).startswith("sqlite+pysqlite://")
+
+        def override_get_session() -> Generator[Session, None, None]:
+            override_session = Session(bind=sqlite_engine)
+            try:
+                yield override_session
+            finally:
+                override_session.close()
+
+        app.dependency_overrides[get_session] = override_get_session
+
+        override_gen = app.dependency_overrides[get_session]()
+        override_session = next(override_gen)
+        override_result = override_session.execute(text("SELECT 1")).scalar_one()
+        assert override_result == 1
+        assert str(override_session.get_bind().url).startswith("sqlite+pysqlite://")
+    finally:
+        if session_gen is not None:
+            session_gen.close()
+        if override_gen is not None:
+            override_gen.close()
+        app.dependency_overrides.pop(get_session, None)
+        configure_engine(default_engine)
+        sqlite_engine.dispose()


### PR DESCRIPTION
## Summary
- add a pydantic BaseSettings wrapper that reads configuration from `.env`/`.env.example` and export it via the config package
- introduce a reusable SQLAlchemy engine/session factory with FastAPI dependency helpers and wire migrations to consume the settings URL
- document the DATABASE_URL option and cover the new session dependency with an in-memory SQLite test

## Testing
- make lint
- make test

------
https://chatgpt.com/codex/tasks/task_e_68d0d29ca620832a8fd53e6437d0fce9