### PR TITLE
docs: add call export runbook

### DIFF
--- a/docs/00‑Core — Синхронизация документации.md
+++ b/docs/00‑Core — Синхронизация документации.md
@@ -254,6 +254,7 @@ Cutover‑gate: чек‑лист отката, readiness review, контакт
 Ключевые метрики: p50/p95 latency по методам, error‑rate (5xx/4xx), success‑rate вебхуков, задержка интеграций (1С/B24), очередь task_events, доля ретраев.
  SLO: p95 чтение ≤ 400 ms, модификации ≤ 700 ms; error‑rate ≤ 1%; webhook delivery ≥ 99% за 15 мин.
  Алерты: превышение SLO 3× за 10 мин; рост 429 > 5% трафика; circuit‑breaker открыт > 60 сек; лаг интеграции > 5 мин.
+ Специализированные пайплайны: runbook выгрузки звонков Bitrix24 — см. [docs/runbooks/call_export.md](runbooks/call_export.md).
 
 9. Data Retention & ПДн
 ПДн в логах маскируются; integration_log хранится 90 дней (агрегаты — 365).

--- a/docs/PRD — Тексты звонков Bitrix24.md
+++ b/docs/PRD — Тексты звонков Bitrix24.md
@@ -116,6 +116,7 @@ F7. Идемпотентность и повторные запуски.
   - `call_export_cost_total` > budget_threshold → warn (email/Slack).
   - Лимиты Bitrix24 (`429`) > 10 за 15 мин → warn, переключение в low‑rate режим.
 - Логи: JSON (`event`, `call_id`, `stage`, `duration_ms`, `error_code`, `correlation_id`). PII (номера телефонов) маскируются.
+- Runbook: [Выгрузка звонков Bitrix24](runbooks/call_export.md) — оперативные действия, мониторинг и ретраи.
 - Дашборды: Grafana панели для статусов, длительности, стоимости, успех/ошибка. QA панель — выборка проверенных файлов.
 
 10) Безопасность, ПДн и соответствие 00‑Core
@@ -174,5 +175,5 @@ F7. Идемпотентность и повторные запуски.
 16) Приложения и ссылки
 - A1. Шаблон запроса ChatGPT для саммари (OneDrive/Notion, ссылка в runbook).
 - A2. OpenAPI anchors Bitrix24 телефонии (см. API‑Contracts v1.1.3, раздел `b24.telephony.calls.*`).
-- A3. Runbook инцидентов: `docs/runbooks/call_export.md` (создать при реализации).
+- A3. Runbook: [Выгрузка звонков Bitrix24](runbooks/call_export.md).
 - A4. Формат CSV (data dictionary) — `docs/specs/call_registry_schema.yaml` (будет добавлен при разработке).

--- a/docs/runbooks/call_export.md
+++ b/docs/runbooks/call_export.md
@@ -1,0 +1,78 @@
+<!-- docs/runbooks/call_export.md -->
+# Runbook — выгрузка звонков Bitrix24 (`call_export`)
+
+## Назначение
+Пайплайн `call_export` отвечает за регулярную выгрузку аудиозаписей и транскриптов звонков из Bitrix24,
+расчёт стоимости распознавания и публикацию отчётов. Документ предназначен для on-call инженеров,
+эксплуатации и продуктовой команды, которые сопровождают выгрузки и инциденты по звонкам.
+
+## Запуск и параметры
+- **Плановый запуск:** cron/оркестратор инициирует run ежедневно в 02:00 UTC (можно изменить в scheduler).
+- **Ручной запуск из контейнера:**
+  ```bash
+  docker compose run --rm app python -m jobs.call_export \
+    --from "2025-08-01" \
+    --to "2025-08-31" \
+    --generate-summary=false
+  ```
+- **Параметры:**
+  | Флаг | Обязателен | Значение по умолчанию | Описание |
+  | --- | --- | --- | --- |
+  | `--from` | да | `today-60d` | Начало периода выгрузки (UTC, ISO-8601). |
+  | `--to` | нет | `today` | Конец периода выгрузки (UTC, ISO-8601, включительно). |
+  | `--generate-summary` | нет | `false` | Создавать ли саммари/теги (увеличивает стоимость). |
+  | `--dry-run` | нет | `false` | Только проверка доступа/квот, без скачивания аудио. |
+
+После запуска убедитесь, что создана запись в таблице `call_exports` со статусом `running`. При ручном
+старте указывайте `Idempotency-Key = hash(period + actor)` для избежания дублей.
+
+## Мониторинг
+- **Grafana:** [Call Export Monitoring](https://grafana.example.com/d/mastermobile-call-export/call-export-overview?orgId=1) —
+  панель в папке `MasterMobile / Integrations` с прогрессом, длительностью и статусами.
+- **Прометей:** ключевые запросы
+  - Общее количество запусков: `sum by (status) (call_export_runs_total{environment="prod"})`
+  - Стоимость транскрипций: `call_export_cost_total{environment="prod"}`
+  - Дополнительно: `call_export_duration_seconds`, `call_transcripts_total`, `call_export_retry_total`.
+- **Логи:** `docker compose logs -f app | jq 'select(.module=="call_export")'` — ищем `stage`, `call_id`, `error`.
+- **Отчёты:** S3/объектное хранилище `exports/<period>/reports/summary_<period>.md` и CSV реестр
+  `exports/<period>/registry/calls_<from>_<to>.csv`.
+
+## Алерты
+| Правило | Порог | Действия |
+| --- | --- | --- |
+| `CallExportRunFailed` | `call_export_runs_total{status="error"} > 0` за 15 мин | Пейдж on-call, проверить логи и статус run. |
+| `CallExportCostBudget` | `call_export_cost_total` > бюджет +20% (5 мин подряд) | Уведомить продакта, подтвердить тариф Whisper. |
+| `CallExportRetryStorm` | `call_export_retry_total` > 50 за 15 мин | Проверить ошибки Bitrix24/Whisper, включить throttling. |
+| `Bitrix24RateLimitWarn` | `integration.b24.rate_limited` события > 10/15 мин | Следовать playbook по лимитам Bitrix24. |
+
+Алерты транслируются в `#ops-alerts` и PagerDuty (SEV-2 по умолчанию).
+
+## Инструкции по инцидентам
+1. Зафиксировать инцидент в ротации (`INC-YYYYMMDD-XX`), классифицировать по `docs/runbooks/incidents.md`.
+2. Проверить статус последнего run через `SELECT * FROM call_exports ORDER BY started_at DESC LIMIT 1;`.
+3. Сравнить фактическое число транскрибированных звонков с ожидаемым (экспорт CSV vs Bitrix24 отчёт).
+4. Анализировать логи с фильтром `correlation_id` → определить проблемные стадии (`fetch_calls`, `download`, `transcribe`).
+5. Проверить интеграционные квоты по [playbook лимитов Bitrix24](../integrations/bitrix24_mapping.md#ограничения-и-квоты).
+6. При недоступности Bitrix24 — включить режим `low_rate=true` (конфиг), развернуть очередь повторов, уведомить интеграции.
+7. При проблемах стоимости — сверить тариф и количество минут, при необходимости отключить `--generate-summary`.
+8. После стабилизации — обновить статус инцидента, приложить ссылки на Grafana и отчёты, создать postmortem при SEV-1/2.
+
+## Ретраи
+- **Авто-ретраи:** Bitrix24 (`429/5xx`) — 5 попыток с бэкоффом 5/15/30/60/120 секунд; Whisper — 3 попытки с 10/30/60 секунд.
+- **Ручной перезапуск звонка:**
+  ```sql
+  UPDATE call_records
+     SET status = 'pending', error_message = NULL, retry_count = retry_count + 1
+   WHERE call_id = '<call_id>'
+     AND run_id = '<run_id>';
+  ```
+  Затем выполнить `python -m jobs.call_export --resume --run-id <run_id>`.
+- **Повторный запуск периода:** только после подтверждения отсутствия дублей в `call_exports`. Используйте `--dry-run` для
+  предварительной оценки стоимости и времени.
+- **DLQ:** если запись ушла в DLQ после 24 часов ретраев — вынести в отдельный тикет, обновить отчёт и уведомить заказчика.
+
+## Связанные материалы
+- PRD: [Тексты звонков Bitrix24](../PRD%20—%20Тексты%20звонков%20Bitrix24.md)
+- Observability: [Метрики и дашборды](../observability.md)
+- Инциденты: [Общий runbook](incidents.md)
+- Playbook: [Лимиты Bitrix24](../integrations/bitrix24_mapping.md#ограничения-и-квоты)


### PR DESCRIPTION
## Summary
- add a dedicated Bitrix24 call export runbook covering launch parameters, monitoring, alerts and retry procedures
- link the PRD and core documentation to the new runbook for operational traceability

## Testing
- not run (docs change only)


------
https://chatgpt.com/codex/tasks/task_e_68d0d872af18832a9977acab4e4c1bd0