### PR TITLE
feat: add returns API routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,28 @@
 - Документация: ./docs
 - Контрибьютинг: ./CONTRIBUTING.md
 - Лицензия: ./LICENSE
+
+## API v1 — быстрые вызовы
+
+- `GET /api/v1/system/ping` — пинг сервисного слоя; заголовок `X-Request-Id` опционален (будет сгенерирован, если не передан).
+- `GET /api/v1/returns` — пагинированный список возвратов. Необязательные query-параметры: `page`, `page_size`.
+- `POST /api/v1/returns` — создание возврата. Требует `Idempotency-Key` (уникальный ≤128 символов) и желательно `X-Request-Id`.
+- `GET /api/v1/returns/{return_id}` — просмотр конкретного возврата.
+- `PUT /api/v1/returns/{return_id}` — полная замена возврата. Требует `Idempotency-Key` и рекомендуемый `X-Request-Id`.
+- `DELETE /api/v1/returns/{return_id}` — удаление возврата. Требует `Idempotency-Key`.
+
+Пример запроса на создание возврата:
+
+```bash
+curl -X POST http://localhost:8000/api/v1/returns \
+  -H "Content-Type: application/json" \
+  -H "Idempotency-Key: $(uuidgen)" \
+  -H "X-Request-Id: $(uuidgen)" \
+  -d '{
+        "source": "warehouse",
+        "courier_id": "courier-001",
+        "items": [
+          {"sku": "SKU-1001", "qty": 1, "quality": "new", "reason_code": "customer_changed_mind"}
+        ]
+      }'
+```

--- a/apps/mw/src/api/dependencies.py
+++ b/apps/mw/src/api/dependencies.py
@@ -1,0 +1,107 @@
+"""Reusable FastAPI dependencies for headers and idempotency handling."""
+from __future__ import annotations
+
+import hashlib
+import threading
+from typing import Annotated
+from uuid import uuid4
+
+from fastapi import Depends, Header, Request, Response, status
+
+from apps.mw.src.api.schemas import Error
+
+
+class ProblemDetailException(Exception):
+    """Exception carrying RFC7807 compliant payload."""
+
+    def __init__(self, error: Error) -> None:
+        super().__init__(error.title)
+        self.error = error
+
+
+_RequestIdHeader = Annotated[str | None, Header(alias="X-Request-Id", max_length=128)]
+_IdempotencyKeyHeader = Annotated[str, Header(alias="Idempotency-Key", max_length=128)]
+
+_IDEMPOTENCY_CACHE: dict[tuple[str, str, str], str] = {}
+_IDEMPOTENCY_LOCK = threading.Lock()
+
+
+def build_error(
+    status_code: int,
+    *,
+    title: str,
+    detail: str | None = None,
+    request_id: str | None = None,
+    type_: str = "about:blank",
+    errors: list[dict[str, str]] | None = None,
+) -> Error:
+    """Construct a problem details object with optional metadata."""
+
+    return Error(
+        type=type_,
+        title=title,
+        status=status_code,
+        detail=detail,
+        errors=errors,
+        request_id=request_id,
+    )
+
+
+def provide_request_id(response: Response, request_id: _RequestIdHeader = None) -> str:
+    """Ensure every response has an `X-Request-Id` header."""
+
+    value = (request_id or str(uuid4())).strip()
+    if not value:
+        value = str(uuid4())
+    response.headers["X-Request-Id"] = value
+    return value
+
+
+async def enforce_idempotency_key(
+    request: Request,
+    response: Response,
+    request_id: str = Depends(provide_request_id),
+    idempotency_key: _IdempotencyKeyHeader = None,
+) -> str:
+    """Validate and track idempotency keys for unsafe HTTP operations."""
+
+    key = (idempotency_key or "").strip()
+    if not key:
+        raise ProblemDetailException(
+            build_error(
+                status.HTTP_422_UNPROCESSABLE_ENTITY,
+                title="Invalid Idempotency-Key header",
+                detail="Idempotency-Key header must not be blank.",
+                request_id=request_id,
+            )
+        )
+
+    body = await request.body()
+    digest = hashlib.sha256(body).hexdigest()
+    cache_key = (request.method.upper(), request.url.path, key)
+
+    response.headers["Idempotency-Key"] = key
+
+    with _IDEMPOTENCY_LOCK:
+        existing = _IDEMPOTENCY_CACHE.get(cache_key)
+        if existing is None:
+            _IDEMPOTENCY_CACHE[cache_key] = digest
+        elif existing != digest:
+            raise ProblemDetailException(
+                build_error(
+                    status.HTTP_409_CONFLICT,
+                    title="Idempotency conflict",
+                    detail="Payload differs from the original request for this Idempotency-Key.",
+                    request_id=request_id,
+                )
+            )
+
+    request.state.idempotency_key = key
+    return key
+
+
+def reset_idempotency_cache() -> None:
+    """Clear stored idempotency fingerprints (primarily for tests)."""
+
+    with _IDEMPOTENCY_LOCK:
+        _IDEMPOTENCY_CACHE.clear()

--- a/apps/mw/src/api/routes/returns.py
+++ b/apps/mw/src/api/routes/returns.py
@@ -1,0 +1,280 @@
+"""CRUD endpoints for managing returns."""
+from __future__ import annotations
+
+import math
+from uuid import UUID, uuid4
+
+from fastapi import APIRouter, Depends, Path, Query, Response, status
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session, selectinload
+
+from apps.mw.src.api.dependencies import (
+    ProblemDetailException,
+    build_error,
+    enforce_idempotency_key,
+    provide_request_id,
+)
+from apps.mw.src.api.schemas import Error, PaginatedReturns, Return, ReturnCreate, ReturnItem
+from apps.mw.src.db.models import Return as ReturnModel
+from apps.mw.src.db.models import ReturnLine as ReturnLineModel
+from apps.mw.src.db.session import get_session
+
+router = APIRouter(
+    prefix="/api/v1/returns",
+    tags=["returns"],
+    dependencies=[Depends(provide_request_id)],
+)
+
+
+def _serialize_return(model: ReturnModel) -> Return:
+    """Convert a SQLAlchemy return entity into a Pydantic schema."""
+
+    items = [
+        ReturnItem(
+            line_id=line.line_id,
+            sku=line.sku,
+            qty=line.qty,
+            quality=line.quality,
+            reason_code=line.reason_code,
+            reason_note=line.reason_note,
+            photos=list(line.photos) if line.photos is not None else None,
+            imei=line.imei,
+            serial=line.serial,
+        )
+        for line in sorted(model.lines, key=lambda item: item.line_id)
+    ]
+
+    return Return(
+        id=str(model.return_id),
+        status=model.status,
+        source=model.source,
+        courier_id=model.courier_id,
+        order_id_1c=model.order_id_1c,
+        manager_id=model.manager_id,
+        comment=model.comment,
+        created_at=model.created_at,
+        updated_at=model.updated_at,
+        items=items,
+    )
+
+
+@router.get(
+    "",
+    response_model=PaginatedReturns,
+    summary="List returns",
+    responses={
+        status.HTTP_400_BAD_REQUEST: {"model": Error, "description": "Invalid request parameters."},
+    },
+)
+def list_returns(
+    page: int = Query(1, ge=1, description="Page number to return."),
+    page_size: int = Query(20, ge=1, le=100, description="Number of items per page."),
+    session: Session = Depends(get_session),
+) -> PaginatedReturns:
+    """Return a paginated list of stored returns."""
+
+    total_items = session.scalar(select(func.count(ReturnModel.return_id))) or 0
+    offset = (page - 1) * page_size
+
+    stmt = (
+        select(ReturnModel)
+        .options(selectinload(ReturnModel.lines))
+        .order_by(ReturnModel.created_at.desc())
+        .offset(offset)
+        .limit(page_size)
+    )
+    returns = session.scalars(stmt).all()
+
+    total_pages = math.ceil(total_items / page_size) if total_items else 0
+    has_next = page < total_pages
+
+    return PaginatedReturns(
+        items=[_serialize_return(record) for record in returns],
+        page=page,
+        page_size=page_size,
+        total_items=total_items,
+        total_pages=total_pages,
+        has_next=has_next,
+    )
+
+
+def _allocate_line_ids(session: Session, count: int) -> list[int | None]:
+    """Allocate primary keys for return lines when required by SQLite."""
+
+    bind = session.get_bind()
+    if bind is not None and bind.dialect.name == "sqlite":
+        max_id = session.scalar(select(func.max(ReturnLineModel.id))) or 0
+        return [max_id + index + 1 for index in range(count)]
+    return [None] * count
+
+
+@router.post(
+    "",
+    response_model=Return,
+    status_code=status.HTTP_201_CREATED,
+    summary="Create a return",
+    responses={
+        status.HTTP_409_CONFLICT: {"model": Error, "description": "Idempotency conflict."},
+    },
+)
+async def create_return(
+    payload: ReturnCreate,
+    response: Response,
+    session: Session = Depends(get_session),
+    _idempotency_key: str = Depends(enforce_idempotency_key),
+) -> Return:
+    """Persist a new return document together with its line items."""
+
+    return_model = ReturnModel(
+        return_id=uuid4(),
+        source=payload.source,
+        courier_id=payload.courier_id,
+        order_id_1c=payload.order_id_1c,
+        comment=payload.comment,
+    )
+
+    line_ids = _allocate_line_ids(session, len(payload.items))
+    for line_pk, item in zip(line_ids, payload.items, strict=False):
+        return_model.lines.append(
+            ReturnLineModel(
+                id=line_pk,
+                line_id=str(uuid4()),
+                sku=item.sku,
+                qty=item.qty,
+                quality=item.quality,
+                reason_code=item.reason_code,
+                reason_note=item.reason_note,
+                photos=list(item.photos) if item.photos is not None else None,
+                imei=item.imei,
+                serial=item.serial,
+            )
+        )
+
+    session.add(return_model)
+    session.commit()
+    session.refresh(return_model)
+
+    response.headers["Location"] = f"/api/v1/returns/{return_model.return_id}"
+    return _serialize_return(return_model)
+
+
+@router.get(
+    "/{return_id}",
+    response_model=Return,
+    summary="Retrieve a return",
+    responses={
+        status.HTTP_404_NOT_FOUND: {"model": Error, "description": "Return was not found."},
+    },
+)
+def get_return(
+    response: Response,
+    return_id: UUID = Path(..., description="Identifier of the return."),
+    session: Session = Depends(get_session),
+) -> Return:
+    """Fetch a single return by its identifier."""
+
+    record = session.get(ReturnModel, return_id)
+    if record is None:
+        error = build_error(
+            status.HTTP_404_NOT_FOUND,
+            title="Return not found",
+            detail=f"Return {return_id} was not found.",
+            request_id=response.headers.get("X-Request-Id"),
+        )
+        raise ProblemDetailException(error)
+
+    session.refresh(record)
+    return _serialize_return(record)
+
+
+@router.put(
+    "/{return_id}",
+    response_model=Return,
+    summary="Update a return",
+    responses={
+        status.HTTP_404_NOT_FOUND: {"model": Error, "description": "Return was not found."},
+        status.HTTP_409_CONFLICT: {"model": Error, "description": "Idempotency conflict."},
+    },
+)
+async def update_return(
+    response: Response,
+    payload: ReturnCreate,
+    return_id: UUID = Path(..., description="Identifier of the return."),
+    session: Session = Depends(get_session),
+    _idempotency_key: str = Depends(enforce_idempotency_key),
+) -> Return:
+    """Replace return fields and line items with supplied payload."""
+
+    record = session.get(ReturnModel, return_id)
+    if record is None:
+        error = build_error(
+            status.HTTP_404_NOT_FOUND,
+            title="Return not found",
+            detail=f"Return {return_id} was not found.",
+            request_id=response.headers.get("X-Request-Id"),
+        )
+        raise ProblemDetailException(error)
+
+    record.source = payload.source
+    record.courier_id = payload.courier_id
+    record.order_id_1c = payload.order_id_1c
+    record.comment = payload.comment
+
+    record.lines.clear()
+    session.flush()
+
+    line_ids = _allocate_line_ids(session, len(payload.items))
+    for line_pk, item in zip(line_ids, payload.items, strict=False):
+        record.lines.append(
+            ReturnLineModel(
+                id=line_pk,
+                line_id=str(uuid4()),
+                sku=item.sku,
+                qty=item.qty,
+                quality=item.quality,
+                reason_code=item.reason_code,
+                reason_note=item.reason_note,
+                photos=list(item.photos) if item.photos is not None else None,
+                imei=item.imei,
+                serial=item.serial,
+            )
+        )
+
+    session.add(record)
+    session.commit()
+    session.refresh(record)
+
+    return _serialize_return(record)
+
+
+@router.delete(
+    "/{return_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="Delete a return",
+    responses={
+        status.HTTP_404_NOT_FOUND: {"model": Error, "description": "Return was not found."},
+        status.HTTP_409_CONFLICT: {"model": Error, "description": "Idempotency conflict."},
+    },
+)
+async def delete_return(
+    response: Response,
+    return_id: UUID = Path(..., description="Identifier of the return."),
+    session: Session = Depends(get_session),
+    _idempotency_key: str = Depends(enforce_idempotency_key),
+) -> None:
+    """Remove a return and all associated line items."""
+
+    record = session.get(ReturnModel, return_id)
+    if record is None:
+        error = build_error(
+            status.HTTP_404_NOT_FOUND,
+            title="Return not found",
+            detail=f"Return {return_id} was not found.",
+            request_id=response.headers.get("X-Request-Id"),
+        )
+        raise ProblemDetailException(error)
+
+    session.delete(record)
+    session.commit()
+
+    response.status_code = status.HTTP_204_NO_CONTENT

--- a/apps/mw/src/api/routes/system.py
+++ b/apps/mw/src/api/routes/system.py
@@ -1,0 +1,26 @@
+"""System level API endpoints."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends
+
+from apps.mw.src.api.dependencies import provide_request_id
+from apps.mw.src.api.schemas import Ping
+
+router = APIRouter(
+    prefix="/api/v1/system",
+    tags=["system"],
+    dependencies=[Depends(provide_request_id)],
+)
+
+
+@router.get("/ping", response_model=Ping, summary="Ping the middleware")
+async def ping() -> Ping:
+    """Return a basic heartbeat payload with current UTC timestamp."""
+
+    return Ping(
+        status="pong",
+        timestamp=datetime.now(timezone.utc),
+        service="master-mobile-middleware",
+    )

--- a/apps/mw/src/api/schemas/__init__.py
+++ b/apps/mw/src/api/schemas/__init__.py
@@ -1,0 +1,23 @@
+"""Pydantic schemas exposed by the API layer."""
+
+from .returns import (
+    Error,
+    Health,
+    PaginatedReturns,
+    Ping,
+    Return,
+    ReturnCreate,
+    ReturnCreateItem,
+    ReturnItem,
+)
+
+__all__ = [
+    "Error",
+    "Health",
+    "PaginatedReturns",
+    "Ping",
+    "Return",
+    "ReturnCreate",
+    "ReturnCreateItem",
+    "ReturnItem",
+]

--- a/apps/mw/src/api/schemas/returns.py
+++ b/apps/mw/src/api/schemas/returns.py
@@ -1,0 +1,173 @@
+"""Pydantic representations for system and return API payloads."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from apps.mw.src.db.models import ReturnLineQuality, ReturnSource, ReturnStatus
+
+
+class APIModel(BaseModel):
+    """Base class enabling ORM serialisation helpers."""
+
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True, use_enum_values=True)
+
+
+class Health(APIModel):
+    """Schema describing the `/health` response payload."""
+
+    status: str = Field(description="Overall health status of the middleware.")
+    version: str | None = Field(
+        default=None,
+        description="Currently deployed API version.",
+    )
+    uptime_seconds: int | None = Field(
+        default=None,
+        description="Uptime of the service in seconds.",
+    )
+
+
+class Ping(APIModel):
+    """Schema returned by `/api/v1/system/ping`."""
+
+    status: str = Field(description="Short status indicator.")
+    timestamp: datetime = Field(description="UTC timestamp of the ping response.")
+    service: str | None = Field(
+        default=None,
+        description="Identifier of the service responding to the ping.",
+    )
+
+
+class Error(APIModel):
+    """Problem Details object returned on API failures."""
+
+    type: str = Field(description="URI identifying the error type.")
+    title: str = Field(description="Short human readable summary of the error.")
+    status: int = Field(description="HTTP status code for the error response.")
+    detail: str | None = Field(
+        default=None,
+        description="Human readable explanation specific to this occurrence.",
+    )
+    errors: list[dict[str, str]] | None = Field(
+        default=None,
+        description="Optional list of field level validation errors.",
+    )
+    request_id: str | None = Field(
+        default=None,
+        description="Identifier correlating the request with logs and traces.",
+    )
+
+
+class ReturnItem(APIModel):
+    """Line item persisted for a return document."""
+
+    line_id: str = Field(description="Identifier of the line item inside the return.")
+    sku: str = Field(description="Stock keeping unit of the returned product.")
+    qty: int = Field(ge=1, description="Quantity being returned.")
+    quality: ReturnLineQuality = Field(description="Quality of the returned item.")
+    reason_code: str = Field(description="Machine readable reason code.")
+    reason_note: str | None = Field(
+        default=None,
+        description="Additional human readable note for the reason.",
+    )
+    photos: list[str] | None = Field(
+        default=None,
+        description="Bitrix24 file identifiers for related photos.",
+    )
+    imei: str | None = Field(
+        default=None,
+        description="IMEI of the returned device when applicable.",
+    )
+    serial: str | None = Field(
+        default=None,
+        description="Serial number of the returned device.",
+    )
+
+
+class Return(APIModel):
+    """Return document exposed by the API."""
+
+    id: str = Field(description="Unique identifier of the return.")
+    status: ReturnStatus = Field(description="Current status of the return.")
+    source: ReturnSource = Field(description="Channel that initiated the return.")
+    courier_id: str = Field(description="Identifier of the courier handling the order.")
+    order_id_1c: str | None = Field(
+        default=None,
+        description="Optional reference to the order in 1C.",
+    )
+    manager_id: str | None = Field(
+        default=None,
+        description="Identifier of the manager who processed the return.",
+    )
+    comment: str | None = Field(
+        default=None,
+        description="Additional notes about the return.",
+    )
+    created_at: datetime = Field(description="When the return was created.")
+    updated_at: datetime = Field(description="When the return was last updated.")
+    items: List[ReturnItem] = Field(
+        description="Items included in the return.",
+        min_length=1,
+    )
+
+
+class ReturnCreateItem(APIModel):
+    """Input line item when creating or updating a return."""
+
+    sku: str = Field(description="Stock keeping unit of the returned product.")
+    qty: int = Field(ge=1, description="Quantity being returned.")
+    quality: ReturnLineQuality = Field(description="Quality of the returned item.")
+    reason_code: str = Field(description="Machine readable reason code.")
+    reason_note: str | None = Field(
+        default=None,
+        description="Additional human readable note for the reason.",
+    )
+    photos: list[str] | None = Field(
+        default=None,
+        description="Bitrix24 file identifiers for related photos.",
+    )
+    imei: str | None = Field(
+        default=None,
+        description="IMEI of the returned device when applicable.",
+    )
+    serial: str | None = Field(
+        default=None,
+        description="Serial number of the returned device.",
+    )
+
+
+class ReturnCreate(APIModel):
+    """Input payload for creating or updating a return."""
+
+    source: ReturnSource = Field(description="Channel that initiated the return.")
+    courier_id: str = Field(
+        description="Identifier of the courier who collected the items from the customer.",
+    )
+    order_id_1c: str | None = Field(
+        default=None,
+        description="Optional reference to the original order in 1C.",
+    )
+    comment: str | None = Field(
+        default=None,
+        description="Additional notes for operators.",
+    )
+    items: List[ReturnCreateItem] = Field(
+        description="Items being returned.",
+        min_length=1,
+    )
+
+
+class PaginatedReturns(APIModel):
+    """Paginated collection of returns."""
+
+    items: List[Return] = Field(description="Page of returns.")
+    page: int = Field(ge=1, description="Current page number.")
+    page_size: int = Field(ge=1, description="Number of items per page.")
+    total_items: int = Field(ge=0, description="Total number of returns available.")
+    total_pages: int = Field(ge=0, description="Total number of pages available.")
+    has_next: bool | None = Field(
+        default=None,
+        description="Indicates if there is another page after the current one.",
+    )

--- a/apps/mw/src/app.py
+++ b/apps/mw/src/app.py
@@ -1,11 +1,83 @@
-from fastapi import FastAPI
+"""FastAPI application setup and router registration."""
+from __future__ import annotations
 
-from .health import get_health_payload
+from typing import Any
+from uuid import uuid4
+
+from fastapi import Depends, FastAPI, Request, Response, status
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+
+from apps.mw.src.api.dependencies import (
+    ProblemDetailException,
+    build_error,
+    provide_request_id,
+)
+from apps.mw.src.api.routes import returns as returns_router
+from apps.mw.src.api.routes import system as system_router
+from apps.mw.src.api.schemas import Error, Health
+from apps.mw.src.health import get_health_payload
 
 app = FastAPI(title="MasterMobile MW")
 
+app.include_router(system_router.router)
+app.include_router(returns_router.router)
 
-@app.get("/health")
-async def health() -> dict[str, str]:
+
+@app.get("/health", response_model=Health)
+async def health(response: Response, request_id: str = Depends(provide_request_id)) -> Health:
     """Simple health-check endpoint used by smoke tests."""
-    return get_health_payload()
+
+    payload = get_health_payload()
+    if isinstance(payload, Health):
+        return payload
+    if isinstance(payload, dict):
+        payload = Health.model_validate(payload)
+    return payload
+
+
+@app.exception_handler(ProblemDetailException)
+async def handle_problem_detail(request: Request, exc: ProblemDetailException) -> JSONResponse:
+    """Render RFC7807 responses raised by dependencies and routes."""
+
+    error = exc.error
+    request_id = error.request_id or request.headers.get("X-Request-Id") or str(uuid4())
+    error = Error(**{**error.model_dump(exclude_none=True), "request_id": request_id})
+    response = JSONResponse(
+        status_code=error.status,
+        content=error.model_dump(exclude_none=True),
+        media_type="application/problem+json",
+    )
+    response.headers["X-Request-Id"] = request_id
+    return response
+
+
+@app.exception_handler(RequestValidationError)
+async def handle_validation_error(request: Request, exc: RequestValidationError) -> JSONResponse:
+    """Convert FastAPI validation errors into problem details responses."""
+
+    request_id = request.headers.get("X-Request-Id") or str(uuid4())
+    errors: list[dict[str, Any]] = []
+    for error in exc.errors():
+        loc = ".".join(str(part) for part in error.get("loc", []) if part not in {"body"})
+        errors.append({
+            "field": loc or "body",
+            "message": error.get("msg", "Invalid value."),
+        })
+
+    problem = build_error(
+        status.HTTP_422_UNPROCESSABLE_ENTITY,
+        title="Validation failed",
+        detail="Request validation failed.",
+        request_id=request_id,
+        type_="https://api.mastermobile.app/errors/validation",
+        errors=errors or None,
+    )
+
+    response = JSONResponse(
+        status_code=problem.status,
+        content=problem.model_dump(exclude_none=True),
+        media_type="application/problem+json",
+    )
+    response.headers["X-Request-Id"] = request_id
+    return response

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -84,8 +84,8 @@ paths:
           headers:
             X-Request-Id:
               $ref: '#/components/headers/XRequestId'
-        '400':
-          description: Invalid filters supplied.
+        '422':
+          description: Validation error.
           content:
             application/problem+json:
               schema:
@@ -128,8 +128,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Return'
-        '400':
-          description: Payload validation error.
+        '422':
+          description: Validation error.
           content:
             application/problem+json:
               schema:
@@ -146,7 +146,7 @@ paths:
           headers:
             X-Request-Id:
               $ref: '#/components/headers/XRequestId'
-  /api/v1/returns/{returnId}:
+  /api/v1/returns/{return_id}:
     parameters:
       - $ref: '#/components/parameters/ReturnId'
     get:
@@ -174,6 +174,15 @@ paths:
               $ref: '#/components/headers/XRequestId'
         '404':
           description: Return was not found.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+        '422':
+          description: Validation error.
           content:
             application/problem+json:
               schema:
@@ -210,8 +219,8 @@ paths:
           headers:
             X-Request-Id:
               $ref: '#/components/headers/XRequestId'
-        '400':
-          description: Payload validation error.
+        '422':
+          description: Validation error.
           content:
             application/problem+json:
               schema:
@@ -252,6 +261,15 @@ paths:
       responses:
         '204':
           description: Return was deleted.
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+        '422':
+          description: Validation error.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
           headers:
             X-Request-Id:
               $ref: '#/components/headers/XRequestId'
@@ -614,7 +632,7 @@ components:
         maximum: 100
         default: 20
     ReturnId:
-      name: returnId
+      name: return_id
       in: path
       required: true
       description: Identifier of the return.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
 dev = [
     "mypy>=1.11",
     "pytest>=8.2",
+    "pytest-asyncio>=0.23",
     "ruff>=0.5"
 ]
 

--- a/tests/test_placeholder.py
+++ b/tests/test_placeholder.py
@@ -1,6 +1,0 @@
-"""Placeholder test suite for initial project scaffolding."""
-
-
-def test_placeholder() -> None:
-    """Always passes to keep pytest green until real tests arrive."""
-    assert True

--- a/tests/test_returns_api.py
+++ b/tests/test_returns_api.py
@@ -1,0 +1,192 @@
+"""Integration tests for the returns API endpoints."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import httpx
+import pytest
+import pytest_asyncio
+from sqlalchemy import create_engine
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import Session
+from sqlalchemy.pool import StaticPool
+
+from apps.mw.src.app import app
+from apps.mw.src.api.dependencies import reset_idempotency_cache
+from apps.mw.src.db.models import Base, Return, ReturnLine
+from apps.mw.src.db.session import configure_engine, engine as default_engine, get_session
+
+BASE_URL = "http://testserver"
+
+
+@pytest.fixture(autouse=True)
+def _clear_idempotency_cache() -> None:
+    reset_idempotency_cache()
+    yield
+    reset_idempotency_cache()
+
+
+@pytest.fixture()
+def sqlite_engine() -> Engine:
+    engine = create_engine(
+        "sqlite+pysqlite:///:memory:",
+        future=True,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine, tables=[Return.__table__, ReturnLine.__table__])
+    configure_engine(engine)
+    yield engine
+    configure_engine(default_engine)
+    engine.dispose()
+
+
+@pytest_asyncio.fixture()
+async def api_client(sqlite_engine: Engine) -> httpx.AsyncClient:
+    def override_get_session() -> Session:
+        session = Session(bind=sqlite_engine)
+        try:
+            yield session
+        finally:
+            session.close()
+
+    app.dependency_overrides[get_session] = override_get_session
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url=BASE_URL) as client:
+        yield client
+    app.dependency_overrides.pop(get_session, None)
+
+
+def _sample_payload() -> dict[str, object]:
+    return {
+        "source": "warehouse",
+        "courier_id": "courier-001",
+        "order_id_1c": "000123",
+        "comment": "Initial pickup",
+        "items": [
+            {
+                "sku": "SKU-1001",
+                "qty": 1,
+                "quality": "new",
+                "reason_code": "customer_changed_mind",
+            }
+        ],
+    }
+
+
+@pytest.mark.asyncio
+async def test_create_and_retrieve_return(api_client: httpx.AsyncClient) -> None:
+    payload = _sample_payload()
+    headers = {"Idempotency-Key": "key-create-1", "X-Request-Id": "req-create-1"}
+
+    create_response = await api_client.post("/api/v1/returns", json=payload, headers=headers)
+    assert create_response.status_code == 201
+    body = create_response.json()
+    return_id = body["id"]
+    assert create_response.headers["Location"].endswith(return_id)
+    assert create_response.headers["Idempotency-Key"] == headers["Idempotency-Key"]
+    assert body["items"]
+
+    list_response = await api_client.get("/api/v1/returns", headers={"X-Request-Id": "req-list-1"})
+    assert list_response.status_code == 200
+    assert any(item["id"] == return_id for item in list_response.json()["items"])
+
+    get_response = await api_client.get(
+        f"/api/v1/returns/{return_id}", headers={"X-Request-Id": "req-get-1"}
+    )
+    assert get_response.status_code == 200
+    assert get_response.json()["id"] == return_id
+
+
+@pytest.mark.asyncio
+async def test_idempotency_conflict_on_different_payload(api_client: httpx.AsyncClient) -> None:
+    payload = _sample_payload()
+    headers = {"Idempotency-Key": "key-conflict", "X-Request-Id": "req-conflict-1"}
+
+    first_response = await api_client.post("/api/v1/returns", json=payload, headers=headers)
+    assert first_response.status_code == 201
+
+    modified_payload = dict(payload)
+    modified_payload["comment"] = "Changed"
+
+    conflict_response = await api_client.post(
+        "/api/v1/returns",
+        json=modified_payload,
+        headers={"Idempotency-Key": "key-conflict", "X-Request-Id": "req-conflict-2"},
+    )
+    assert conflict_response.status_code == 409
+    problem = conflict_response.json()
+    assert problem["title"] == "Idempotency conflict"
+    assert problem["status"] == 409
+
+
+@pytest.mark.asyncio
+async def test_update_return_replaces_items(api_client: httpx.AsyncClient) -> None:
+    headers = {"Idempotency-Key": "key-update-1", "X-Request-Id": "req-update-1"}
+    create_response = await api_client.post("/api/v1/returns", json=_sample_payload(), headers=headers)
+    return_id = create_response.json()["id"]
+
+    update_payload = {
+        "source": "warehouse",
+        "courier_id": "courier-002",
+        "order_id_1c": "000124",
+        "comment": "Updated items",
+        "items": [
+            {
+                "sku": "SKU-2002",
+                "qty": 2,
+                "quality": "defect",
+                "reason_code": "damaged_package",
+                "reason_note": "Box was crushed",
+            }
+        ],
+    }
+    update_headers = {"Idempotency-Key": "key-update-2", "X-Request-Id": "req-update-2"}
+    update_response = await api_client.put(
+        f"/api/v1/returns/{return_id}", json=update_payload, headers=update_headers
+    )
+    assert update_response.status_code == 200
+    updated = update_response.json()
+    assert updated["courier_id"] == "courier-002"
+    assert updated["items"][0]["sku"] == "SKU-2002"
+    assert updated["items"][0]["qty"] == 2
+
+
+@pytest.mark.asyncio
+async def test_delete_return_removes_resource(api_client: httpx.AsyncClient) -> None:
+    headers = {"Idempotency-Key": "key-delete-1", "X-Request-Id": "req-delete-1"}
+    create_response = await api_client.post("/api/v1/returns", json=_sample_payload(), headers=headers)
+    return_id = create_response.json()["id"]
+
+    delete_headers = {"Idempotency-Key": "key-delete-2", "X-Request-Id": "req-delete-2"}
+    delete_response = await api_client.delete(
+        f"/api/v1/returns/{return_id}", headers=delete_headers
+    )
+    assert delete_response.status_code == 204
+
+    missing_response = await api_client.get(
+        f"/api/v1/returns/{return_id}", headers={"X-Request-Id": "req-delete-3"}
+    )
+    assert missing_response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_missing_idempotency_key_triggers_validation_error(
+    api_client: httpx.AsyncClient,
+) -> None:
+    response = await api_client.post("/api/v1/returns", json=_sample_payload())
+    assert response.status_code == 422
+    payload = response.json()
+    assert payload["title"] == "Invalid Idempotency-Key header"
+    assert payload["status"] == 422
+
+
+@pytest.mark.asyncio
+async def test_get_unknown_return_returns_not_found(api_client: httpx.AsyncClient) -> None:
+    response = await api_client.get(
+        f"/api/v1/returns/{uuid4()}", headers={"X-Request-Id": "req-missing-1"}
+    )
+    assert response.status_code == 404
+    payload = response.json()
+    assert payload["title"] == "Return not found"

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,13 +1,30 @@
-import pytest
+"""Smoke tests ensuring primary endpoints respond successfully."""
 
 import httpx
+import pytest
 
-BASE_URL = "http://localhost:8000"
+from apps.mw.src.app import app
+
+BASE_URL = "http://testserver"
 
 
 @pytest.mark.asyncio
-async def test_health() -> None:
-    async with httpx.AsyncClient(base_url=BASE_URL) as client:
+async def test_health_endpoint_returns_ok() -> None:
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url=BASE_URL) as client:
         response = await client.get("/health")
     assert response.status_code == 200
     assert response.json().get("status") == "ok"
+    assert "X-Request-Id" in response.headers
+
+
+@pytest.mark.asyncio
+async def test_system_ping_returns_status_and_timestamp() -> None:
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url=BASE_URL) as client:
+        response = await client.get("/api/v1/system/ping")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload.get("status") == "pong"
+    assert "timestamp" in payload
+    assert response.headers.get("X-Request-Id")


### PR DESCRIPTION
## Summary
- add API schemas for health, ping, errors and returns payloads
- implement system ping plus returns CRUD routes with idempotency and request id handling
- refresh OpenAPI, documentation and automated tests for the new endpoints

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d0d7074940832abf7a1b5cc1993e64