### PR TITLE
feat: configure ChatGPT proxy support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,8 @@ DB_NAME=mastermobile
 
 REDIS_HOST=redis
 REDIS_PORT=6379
+# Прокси для исходящих запросов к ChatGPT (используется HTTP-клиентами интеграции)
+CHATGPT_PROXY_URL=http://user150107:dx4a5m@102.129.178.65:6517
 
 LOG_LEVEL=INFO
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@
 | `DB_NAME`       | `mastermobile`         | Имя базы данных                     |
 | `REDIS_HOST`    | `redis`                | Хост Redis                          |
 | `REDIS_PORT`    | `6379`                 | Порт Redis                          |
+| `CHATGPT_PROXY_URL` | `http://user150107:dx4a5m@102.129.178.65:6517` | Прокси-сервер для исходящих запросов к ChatGPT |
 | `LOG_LEVEL`     | `INFO`                 | Уровень логирования приложения      |
 | `JWT_SECRET`    | `changeme`             | Секрет для подписи JWT-токенов      |
 | `JWT_ISSUER`    | `mastermobile`         | Значение `iss` в выданных JWT       |

--- a/apps/mw/src/config/settings.py
+++ b/apps/mw/src/config/settings.py
@@ -30,6 +30,10 @@ class Settings(BaseSettings):
 
     redis_host: str = Field(default="redis", alias="REDIS_HOST")
     redis_port: int = Field(default=6379, alias="REDIS_PORT")
+    chatgpt_proxy_url: str = Field(
+        default="http://user150107:dx4a5m@102.129.178.65:6517",
+        alias="CHATGPT_PROXY_URL",
+    )
 
     log_level: str = Field(default="INFO", alias="LOG_LEVEL")
     jwt_secret: str = Field(default="changeme", alias="JWT_SECRET")

--- a/docs/runbooks/local_dev.md
+++ b/docs/runbooks/local_dev.md
@@ -30,7 +30,7 @@
 ### 1. Подготовка окружения
 - Создайте `.env` из примера и дополните секреты при необходимости.
 - Проверьте новые переменные конфигурации: `JWT_SECRET`, `JWT_ISSUER`, `CORS_ORIGINS`,
-  `MAX_PAGE_SIZE`, `REQUEST_TIMEOUT_S`, `ENABLE_TRACING`, а также флаги
+  `MAX_PAGE_SIZE`, `REQUEST_TIMEOUT_S`, `ENABLE_TRACING`, `CHATGPT_PROXY_URL`, а также флаги
   `PII_MASKING_ENABLED` и `DISK_ENCRYPTION_FLAG` для сценариев безопасности.
 - Выполните `make init` — создаст `.venv`, установит `ruff`, `mypy`, `pytest`, Alembic и runtime-зависимости.
 - Для чистого старта удалите контейнеры/volumes: `make down`.


### PR DESCRIPTION
## Summary
- add ChatGPT proxy sample to the environment template and expose it via the settings model
- document the ChatGPT proxy usage for future clients in the README and local development runbook

## Testing
- make lint *(fails: existing Ruff violations in apps/mw/src/api/routes/returns.py, tests/test_returns_api.py, tests/test_smoke.py, and typing updates flagged in schemas)*
- make typecheck *(fails: existing mypy errors in apps/mw/src/api/dependencies.py and apps/mw/src/app.py)*
- make test


------
https://chatgpt.com/codex/tasks/task_e_68d799abb8d4832aba8af3e82bc644bf