### PR TITLE
chore: extend environment configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,8 +10,31 @@ DB_NAME=mastermobile
 
 REDIS_HOST=redis
 REDIS_PORT=6379
-# Прокси для исходящих запросов к ChatGPT (используется HTTP-клиентами интеграции)
-CHATGPT_PROXY_URL=http://user150107:dx4a5m@102.129.178.65:6517
+
+# Настройки интеграции Bitrix24
+B24_BASE_URL=https://example.bitrix24.ru/rest
+B24_WEBHOOK_USER_ID=1
+B24_WEBHOOK_TOKEN=changeme
+B24_RATE_LIMIT_RPS=2.0
+B24_BACKOFF_SECONDS=5
+
+# Настройки OpenAI/Whisper (оставьте пустыми для отключения STT)
+OPENAI_API_KEY=
+OPENAI_BASE_URL=https://api.openai.com/v1
+WHISPER_RATE_PER_MIN_USD=0.006
+STT_MAX_FILE_MINUTES=0
+
+# Прокси для исходящих запросов к ChatGPT/Whisper
+CHATGPT_PROXY_URL=http://proxy.example.com:8080
+
+# Настройки хранилища файлов
+STORAGE_BACKEND=local
+S3_ENDPOINT_URL=
+S3_REGION=
+S3_BUCKET=
+S3_ACCESS_KEY_ID=
+S3_SECRET_ACCESS_KEY=
+LOCAL_STORAGE_DIR=/app/storage
 
 LOG_LEVEL=INFO
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,23 @@
 | `DB_NAME`       | `mastermobile`         | Имя базы данных                     |
 | `REDIS_HOST`    | `redis`                | Хост Redis                          |
 | `REDIS_PORT`    | `6379`                 | Порт Redis                          |
-| `CHATGPT_PROXY_URL` | `http://user150107:dx4a5m@102.129.178.65:6517` | Прокси-сервер для исходящих запросов к ChatGPT |
+| `B24_BASE_URL`  | `https://example.bitrix24.ru/rest` | Базовый URL REST Bitrix24 |
+| `B24_WEBHOOK_USER_ID` | `1`            | Идентификатор пользователя webhook Bitrix24 |
+| `B24_WEBHOOK_TOKEN` | `changeme`        | Токен webhook Bitrix24 (замените в `.env`) |
+| `B24_RATE_LIMIT_RPS` | `2.0`            | Лимит запросов к Bitrix24 в секунду |
+| `B24_BACKOFF_SECONDS` | `5`             | Стартовый шаг экспоненциального бэкоффа |
+| `OPENAI_API_KEY` | —                    | Ключ OpenAI; оставьте пустым, если STT недоступно |
+| `OPENAI_BASE_URL` | `https://api.openai.com/v1` | Базовый URL OpenAI/совместимого API |
+| `WHISPER_RATE_PER_MIN_USD` | `0.006`    | Ставка Whisper за минуту аудио (для расчёта стоимости) |
+| `STT_MAX_FILE_MINUTES` | `0`            | Максимальная длительность файла для STT; `0` отключает обработку |
+| `CHATGPT_PROXY_URL` | `http://proxy.example.com:8080` | HTTP-прокси для исходящих запросов к ChatGPT/Whisper |
+| `STORAGE_BACKEND` | `local`             | Тип хранилища (`local` или `s3`) |
+| `S3_ENDPOINT_URL` | —                   | Кастомный endpoint S3 (для minio/совместимых сервисов) |
+| `S3_REGION`     | —                     | Регион S3 |
+| `S3_BUCKET`     | —                     | Имя S3-бакета для хранения артефактов |
+| `S3_ACCESS_KEY_ID` | —                  | Access key для S3 |
+| `S3_SECRET_ACCESS_KEY` | —             | Secret key для S3 |
+| `LOCAL_STORAGE_DIR` | `/app/storage`    | Путь локального хранилища (монтируется в контейнер `app`) |
 | `LOG_LEVEL`     | `INFO`                 | Уровень логирования приложения      |
 | `JWT_SECRET`    | `changeme`             | Секрет для подписи JWT-токенов      |
 | `JWT_ISSUER`    | `mastermobile`         | Значение `iss` в выданных JWT       |
@@ -41,9 +57,10 @@
 | `ENABLE_TRACING` | `false`                | Включение экспорта трассировок OpenTelemetry |
 | `PII_MASKING_ENABLED` | `false`           | Маскирование персональных данных в логах |
 | `DISK_ENCRYPTION_FLAG` | `false`          | Флаг шифрования томов/дисков (prod → `true`) |
-| `CHATGPT_PROXY_URL` | `http://user150107:dx4a5m@102.129.178.65:6517` | Корпоративный прокси для исходящих запросов к ChatGPT/Whisper |
 
 > Все значения можно переопределить в `.env` перед запуском `docker compose` / `make up`.
+
+> При пустом `OPENAI_API_KEY` или значении `STT_MAX_FILE_MINUTES=0` сервис стартует без обработки STT: запросы на транскрибацию пропускаются, очередь заданий не создаётся.
 
 ## Архитектура (вкратце)
 - FastAPI (apps/mw/src)

--- a/apps/mw/src/config/settings.py
+++ b/apps/mw/src/config/settings.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from functools import lru_cache
+from typing import Literal
 
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -30,10 +31,32 @@ class Settings(BaseSettings):
 
     redis_host: str = Field(default="redis", alias="REDIS_HOST")
     redis_port: int = Field(default=6379, alias="REDIS_PORT")
-    chatgpt_proxy_url: str = Field(
-        default="http://user150107:dx4a5m@102.129.178.65:6517",
-        alias="CHATGPT_PROXY_URL",
+
+    b24_base_url: str = Field(default="https://example.bitrix24.ru/rest", alias="B24_BASE_URL")
+    b24_webhook_user_id: int = Field(default=1, alias="B24_WEBHOOK_USER_ID")
+    b24_webhook_token: str = Field(default="changeme", alias="B24_WEBHOOK_TOKEN")
+    b24_rate_limit_rps: float = Field(default=2.0, alias="B24_RATE_LIMIT_RPS")
+    b24_backoff_seconds: int = Field(default=5, alias="B24_BACKOFF_SECONDS")
+
+    openai_api_key: str | None = Field(default=None, alias="OPENAI_API_KEY")
+    openai_base_url: str = Field(default="https://api.openai.com/v1", alias="OPENAI_BASE_URL")
+    whisper_rate_per_min_usd: float = Field(
+        default=0.006,
+        alias="WHISPER_RATE_PER_MIN_USD",
     )
+    stt_max_file_minutes: int = Field(default=0, alias="STT_MAX_FILE_MINUTES")
+    chatgpt_proxy_url: str | None = Field(default=None, alias="CHATGPT_PROXY_URL")
+
+    storage_backend: Literal["local", "s3"] = Field(
+        default="local",
+        alias="STORAGE_BACKEND",
+    )
+    s3_endpoint_url: str | None = Field(default=None, alias="S3_ENDPOINT_URL")
+    s3_region: str | None = Field(default=None, alias="S3_REGION")
+    s3_bucket: str | None = Field(default=None, alias="S3_BUCKET")
+    s3_access_key_id: str | None = Field(default=None, alias="S3_ACCESS_KEY_ID")
+    s3_secret_access_key: str | None = Field(default=None, alias="S3_SECRET_ACCESS_KEY")
+    local_storage_dir: str = Field(default="/app/storage", alias="LOCAL_STORAGE_DIR")
 
     log_level: str = Field(default="INFO", alias="LOG_LEVEL")
     jwt_secret: str = Field(default="changeme", alias="JWT_SECRET")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,24 @@ services:
     env_file:
       - .env
       - .env.example
+    environment:
+      B24_BASE_URL: ${B24_BASE_URL:-https://example.bitrix24.ru/rest}
+      B24_WEBHOOK_USER_ID: ${B24_WEBHOOK_USER_ID:-1}
+      B24_WEBHOOK_TOKEN: ${B24_WEBHOOK_TOKEN:-changeme}
+      B24_RATE_LIMIT_RPS: ${B24_RATE_LIMIT_RPS:-2.0}
+      B24_BACKOFF_SECONDS: ${B24_BACKOFF_SECONDS:-5}
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      OPENAI_BASE_URL: ${OPENAI_BASE_URL:-https://api.openai.com/v1}
+      WHISPER_RATE_PER_MIN_USD: ${WHISPER_RATE_PER_MIN_USD:-0.006}
+      STT_MAX_FILE_MINUTES: ${STT_MAX_FILE_MINUTES:-0}
+      CHATGPT_PROXY_URL: ${CHATGPT_PROXY_URL:-http://proxy.example.com:8080}
+      STORAGE_BACKEND: ${STORAGE_BACKEND:-local}
+      S3_ENDPOINT_URL: ${S3_ENDPOINT_URL:-}
+      S3_REGION: ${S3_REGION:-}
+      S3_BUCKET: ${S3_BUCKET:-}
+      S3_ACCESS_KEY_ID: ${S3_ACCESS_KEY_ID:-}
+      S3_SECRET_ACCESS_KEY: ${S3_SECRET_ACCESS_KEY:-}
+      LOCAL_STORAGE_DIR: ${LOCAL_STORAGE_DIR:-/app/storage}
     depends_on:
       db:
         condition: service_healthy
@@ -20,6 +38,7 @@ services:
       - "${APP_PORT:-8000}:8000"
     volumes:
       - .:/app
+      - ./storage:${LOCAL_STORAGE_DIR:-/app/storage}
     healthcheck:
       test: ["CMD-SHELL", "curl -fsS http://localhost:${APP_PORT:-8000}/health || exit 1"]
       interval: 10s


### PR DESCRIPTION
## Summary
- add Bitrix24, OpenAI/STT, and storage environment placeholders to `.env.example`
- extend the FastAPI settings model with typed defaults for the new integrations
- expose the variables via docker-compose and document the configuration in the README

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7c0805808832ab99a6dac0ce45a9a