### PR TITLE
Add Docs CI workflow

### DIFF
--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -1,0 +1,54 @@
+name: Docs CI
+
+on:
+  push:
+    paths:
+      - 'README.md'
+      - 'docs/**'
+      - '.github/workflows/docs-ci.yml'
+      - 'pyproject.toml'
+  pull_request:
+    paths:
+      - 'README.md'
+      - 'docs/**'
+      - '.github/workflows/docs-ci.yml'
+      - 'pyproject.toml'
+
+jobs:
+  markdownlint:
+    name: Markdown lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Run markdownlint-cli2
+        uses: DavidAnson/markdownlint-cli2-action@v15
+        with:
+          globs: |
+            README.md
+            docs/**/*.md
+
+  lychee:
+    name: Link check (lychee)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Run lychee link checker
+        uses: lycheeverse/lychee-action@v1
+        with:
+          args: --verbose --no-progress --timeout 30 README.md docs/
+
+  codespell:
+    name: Spell check (codespell)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Run codespell
+        uses: codespell-project/actions-codespell@v2
+        with:
+          path: |
+            README.md
+            docs
+          skip: '*.json'

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # MasterMobile — Middleware & Integrations (FastAPI)
 
+[![Docs CI](https://github.com/mastermobile/mastermobile/actions/workflows/docs-ci.yml/badge.svg)](https://github.com/mastermobile/mastermobile/actions/workflows/docs-ci.yml)
+
 ## Что это
 Единый middleware-сервис: интеграция 1С (УТ 10.3/11), Bitrix24 и «Walking Warehouse».
 


### PR DESCRIPTION
## Summary
- add a dedicated docs CI workflow with markdownlint, lychee, and codespell checks
- surface the new workflow in the README status badges

## Testing
- not run (CI only)


------
https://chatgpt.com/codex/tasks/task_e_68d7c09cf9b8832a8d02ff49d2a45968