### PR TITLE
fix: normalize Bitrix24 ping base URL handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,7 @@ REDIS_HOST=redis
 REDIS_PORT=6379
 
 # Настройки интеграции Bitrix24
+# Укажите базовый URL портала; допустимы формы с и без завершающего "/rest".
 B24_BASE_URL=https://example.bitrix24.ru/rest
 B24_WEBHOOK_USER_ID=1
 B24_WEBHOOK_TOKEN=changeme

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 | `DB_NAME`       | `mastermobile`         | Имя базы данных                     |
 | `REDIS_HOST`    | `redis`                | Хост Redis                          |
 | `REDIS_PORT`    | `6379`                 | Порт Redis                          |
-| `B24_BASE_URL`  | `https://example.bitrix24.ru/rest` | Базовый URL REST Bitrix24 |
+| `B24_BASE_URL`  | `https://example.bitrix24.ru/rest` | Базовый URL REST Bitrix24 (можно указывать с или без завершающего `/rest`) |
 | `B24_WEBHOOK_USER_ID` | `1`            | Идентификатор пользователя webhook Bitrix24 |
 | `B24_WEBHOOK_TOKEN` | `changeme`        | Токен webhook Bitrix24 (замените в `.env`) |
 | `B24_RATE_LIMIT_RPS` | `2.0`            | Лимит запросов к Bitrix24 в секунду |

--- a/scripts/b24_ping.py
+++ b/scripts/b24_ping.py
@@ -5,7 +5,9 @@ Usage:
     python scripts/b24_ping.py
 
 Required environment variables (can be provided via a `.env` file in the project root):
-    B24_BASE_URL         Base URL of the Bitrix24 portal, for example https://example.bitrix24.ru
+    B24_BASE_URL         Base URL of the Bitrix24 portal, for example
+                         https://example.bitrix24.ru/rest (the script also accepts
+                         https://example.bitrix24.ru)
     B24_WEBHOOK_USER_ID  Numeric identifier of the webhook user (the first number in the webhook URL)
     B24_WEBHOOK_TOKEN    Secret token part of the webhook URL
 
@@ -41,6 +43,8 @@ def build_request_url(base_url: str, user_id: str, token: str) -> str:
     """Construct the Bitrix24 REST endpoint URL."""
 
     normalized_base = base_url.rstrip("/")
+    if normalized_base.endswith("/rest"):
+        normalized_base = normalized_base[: -len("/rest")]
     return f"{normalized_base}/rest/{user_id}/{token}/voximplant.statistic.get.json"
 
 

--- a/tests/test_b24_ping.py
+++ b/tests/test_b24_ping.py
@@ -1,0 +1,30 @@
+"""Tests for the Bitrix24 ping helper script."""
+
+from importlib import util
+from pathlib import Path
+
+import pytest
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "scripts" / "b24_ping.py"
+SPEC = util.spec_from_file_location("scripts.b24_ping", MODULE_PATH)
+if SPEC is None or SPEC.loader is None:  # pragma: no cover - defensive guard for import errors
+    raise RuntimeError("Failed to load scripts.b24_ping module")
+
+b24_ping = util.module_from_spec(SPEC)
+SPEC.loader.exec_module(b24_ping)
+
+
+@pytest.mark.parametrize(
+    ("base_url", "expected"),
+    (
+        ("https://example.bitrix24.ru", "https://example.bitrix24.ru/rest/1/token/voximplant.statistic.get.json"),
+        ("https://example.bitrix24.ru/", "https://example.bitrix24.ru/rest/1/token/voximplant.statistic.get.json"),
+        ("https://example.bitrix24.ru/rest", "https://example.bitrix24.ru/rest/1/token/voximplant.statistic.get.json"),
+        ("https://example.bitrix24.ru/rest/", "https://example.bitrix24.ru/rest/1/token/voximplant.statistic.get.json"),
+    ),
+)
+def test_build_request_url_handles_base_variants(base_url: str, expected: str) -> None:
+    """The request URL must be consistent regardless of trailing `/rest` in the base."""
+
+    actual = b24_ping.build_request_url(base_url, "1", "token")
+    assert actual == expected


### PR DESCRIPTION
## Summary
- update the Bitrix24 ping script to normalize the base URL when building requests and clarify the accepted forms in the usage docs
- align README and `.env.example` guidance so both `/rest` and non-`/rest` base URLs are documented
- add a test covering multiple base URL inputs to prevent regressions

## Testing
- PYTHONPATH=. pytest tests/test_b24_ping.py

------
https://chatgpt.com/codex/tasks/task_e_68d7c6d62ad4832a9cf454e068ed54fd