### PR TITLE
feat: add Bitrix24 recording hint in ping script

### DIFF
--- a/scripts/b24_ping.py
+++ b/scripts/b24_ping.py
@@ -134,7 +134,10 @@ def main() -> None:
     if example_recording:
         print(f"recording_url (example): {example_recording}")
     else:
-        print("recording_url (example): not available")
+        print(
+            "recording_url (example): not available — enable call recording in Bitrix24 "
+            "or check webhook permissions."
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_b24_ping.py
+++ b/tests/test_b24_ping.py
@@ -28,3 +28,26 @@ def test_build_request_url_handles_base_variants(base_url: str, expected: str) -
 
     actual = b24_ping.build_request_url(base_url, "1", "token")
     assert actual == expected
+
+
+def test_main_prints_hint_when_no_recordings(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    """When recordings are missing, the operator should see actionable guidance."""
+
+    class DummyResponse:
+        status_code = 200
+
+        @staticmethod
+        def json() -> dict:
+            return {"result": [{"ID": 1}]}
+
+    monkeypatch.setattr(b24_ping, "load_environment", lambda: None)
+    monkeypatch.setattr(b24_ping, "fetch_statistics", lambda *args, **kwargs: DummyResponse())
+    monkeypatch.setenv("B24_BASE_URL", "https://example.bitrix24.ru")
+    monkeypatch.setenv("B24_WEBHOOK_USER_ID", "1")
+    monkeypatch.setenv("B24_WEBHOOK_TOKEN", "token")
+
+    b24_ping.main()
+
+    captured = capsys.readouterr()
+    assert "recording_url (example): not available" in captured.out
+    assert "enable call recording in Bitrix24" in captured.out


### PR DESCRIPTION
## Summary
- surface a Bitrix24 call-recording hint when the ping script cannot show an example
- cover the missing-recording flow with a dedicated pytest

## Testing
- PYTHONPATH=. pytest tests/test_b24_ping.py

------
https://chatgpt.com/codex/tasks/task_e_68d7c8dda200832a8464cae14277f0c2