### PR TITLE
Fix docs CI badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MasterMobile — Middleware & Integrations (FastAPI)
 
-[![Docs CI](https://github.com/mastermobile/mastermobile/actions/workflows/docs-ci.yml/badge.svg)](https://github.com/mastermobile/mastermobile/actions/workflows/docs-ci.yml)
+[![Docs CI](https://github.com/Offonika/mastermobile/actions/workflows/docs-ci.yml/badge.svg)](https://github.com/Offonika/mastermobile/actions/workflows/docs-ci.yml)
 
 ## Что это
 Единый middleware-сервис: интеграция 1С (УТ 10.3/11), Bitrix24 и «Walking Warehouse».


### PR DESCRIPTION
## Summary
- update the README Docs CI badge to point to the Offonika/mastermobile workflow

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7c9eb0154832aa0103601a8971541