### PR TITLE
docs: confirm runbook availability for b24 exports

### DIFF
--- a/docs/PRD — Тексты звонков Bitrix24.md
+++ b/docs/PRD — Тексты звонков Bitrix24.md
@@ -177,6 +177,6 @@ F7. Идемпотентность и повторные запуски.
 - A1. Шаблон запроса ChatGPT для саммари (OneDrive/Notion, ссылка в runbook).
 - A2. OpenAPI anchors Bitrix24 телефонии (см. API‑Contracts v1.1.3, раздел `b24.telephony.calls.*`).
 
-- A3. Runbook инцидентов: `docs/runbooks/call_export.md` (создать при реализации).
+- A3. Runbook инцидентов: [docs/runbooks/call_export.md](runbooks/call_export.md) — доступен к использованию.
 - A4. Формат CSV (data dictionary) — [docs/specs/call_registry_schema.yaml](specs/call_registry_schema.yaml).
 


### PR DESCRIPTION
## Summary
- update PRD runbook reference to point to the existing call export playbook
- ensure the link renders correctly in Markdown preview

## Testing
- python - <<'PY'
import markdown
from pathlib import Path
text = Path('docs/PRD — Тексты звонков Bitrix24.md').read_text(encoding='utf-8')
html = markdown.markdown(text)
start = html.split('Runbook инцидентов')[1].split('</li>')[0]
print(start)
PY

------
https://chatgpt.com/codex/tasks/task_e_68d7ca3d92a0832a994bd0adfaf8bc13