### PR TITLE
feat: add call export and call record persistence

### DIFF
--- a/apps/mw/migrations/versions/0003_call_exports_call_records.py
+++ b/apps/mw/migrations/versions/0003_call_exports_call_records.py
@@ -1,0 +1,162 @@
+"""Create tables for Bitrix24 call exports and records."""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "0003_call_exports_call_records"
+down_revision = "0002_return_lines_defect_reason_check"
+branch_labels = None
+depends_on = None
+
+
+CALL_EXPORT_STATUS_CHECK = (
+    "status IN ('pending','in_progress','completed','error','cancelled')"
+)
+
+CALL_RECORD_STATUS_CHECK = (
+    "status IN ('pending','downloading','downloaded','transcribing','completed','skipped','error')"
+)
+
+
+def upgrade() -> None:
+    op.create_table(
+        "call_exports",
+        sa.Column(
+            "run_id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+        ),
+        sa.Column("period_from", sa.TIMESTAMP(timezone=True), nullable=False),
+        sa.Column("period_to", sa.TIMESTAMP(timezone=True), nullable=False),
+        sa.Column("status", sa.Text(), nullable=False),
+        sa.Column(
+            "started_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column("finished_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column(
+            "actor_user_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("core.users.user_id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("options", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.CheckConstraint(CALL_EXPORT_STATUS_CHECK, name="chk_call_exports_status"),
+        sa.CheckConstraint(
+            "period_to >= period_from", name="chk_call_exports_period"
+        ),
+    )
+
+    op.create_table(
+        "call_records",
+        sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
+        sa.Column("run_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("call_id", sa.Text(), nullable=False),
+        sa.Column("record_id", sa.Text(), nullable=True),
+        sa.Column("call_started_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("duration_sec", sa.Integer(), nullable=False),
+        sa.Column("recording_url", sa.Text(), nullable=True),
+        sa.Column("storage_path", sa.Text(), nullable=True),
+        sa.Column("transcript_path", sa.Text(), nullable=True),
+        sa.Column("transcript_lang", sa.Text(), nullable=True),
+        sa.Column("checksum", sa.Text(), nullable=True),
+        sa.Column("cost_amount", sa.Numeric(12, 2), nullable=True),
+        sa.Column(
+            "cost_currency",
+            sa.String(length=3),
+            nullable=True,
+            server_default=sa.text("'RUB'"),
+        ),
+        sa.Column("status", sa.Text(), nullable=False),
+        sa.Column("error_code", sa.Text(), nullable=True),
+        sa.Column("error_message", sa.Text(), nullable=True),
+        sa.Column(
+            "attempts",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        sa.Column("last_attempt_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.ForeignKeyConstraint(
+            ["run_id"], ["call_exports.run_id"], ondelete="CASCADE"
+        ),
+        sa.CheckConstraint(
+            "duration_sec >= 0", name="chk_call_records_duration_non_negative"
+        ),
+        sa.CheckConstraint(
+            "attempts >= 0", name="chk_call_records_attempts_non_negative"
+        ),
+        sa.CheckConstraint(
+            CALL_RECORD_STATUS_CHECK, name="chk_call_records_status"
+        ),
+    )
+
+    op.create_index(
+        "idx_call_exports_status_active",
+        "call_exports",
+        ["status"],
+        postgresql_where=sa.text(
+            "status IN ('pending','in_progress','error')"
+        ),
+    )
+
+    op.create_index(
+        "idx_call_records_status_run",
+        "call_records",
+        ["status", "run_id"],
+        postgresql_where=sa.text(
+            "status IN ('pending','downloading','transcribing','error')"
+        ),
+    )
+
+    op.create_index(
+        "idx_call_records_checksum",
+        "call_records",
+        ["checksum"],
+        postgresql_where=sa.text("checksum IS NOT NULL"),
+    )
+
+    op.create_index(
+        "uq_call_records_run_call_record",
+        "call_records",
+        ["run_id", "call_id", sa.text("coalesce(record_id, '')")],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("uq_call_records_run_call_record", table_name="call_records")
+    op.drop_index("idx_call_records_checksum", table_name="call_records")
+    op.drop_index("idx_call_records_status_run", table_name="call_records")
+    op.drop_index("idx_call_exports_status_active", table_name="call_exports")
+    op.drop_table("call_records")
+    op.drop_table("call_exports")

--- a/tests/test_db_models_call_exports.py
+++ b/tests/test_db_models_call_exports.py
@@ -1,0 +1,183 @@
+"""Integration tests for call export and call record ORM models."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from uuid import UUID, uuid4
+
+import pytest
+from sqlalchemy import Column, Table, create_engine, event, insert, select
+from sqlalchemy.dialects.postgresql import UUID as PGUUID
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from apps.mw.src.db.models import (
+    Base,
+    CallExport,
+    CallExportStatus,
+    CallRecord,
+    CallRecordStatus,
+)
+
+
+def _ensure_core_users_table() -> Table:
+    if "core.users" not in Base.metadata.tables:
+        return Table(
+            "core.users",
+            Base.metadata,
+            Column("user_id", PGUUID(as_uuid=True), primary_key=True),
+        )
+    return Base.metadata.tables["core.users"]
+
+
+def _sqlite_engine():
+    engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+
+    @event.listens_for(engine, "connect")
+    def _set_sqlite_pragma(dbapi_connection, connection_record):  # pragma: no cover - event hook
+        cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+
+    return engine
+
+
+def test_call_export_crud_matches_schema() -> None:
+    """Persist, update and delete a call export run."""
+
+    engine = _sqlite_engine()
+    core_users = _ensure_core_users_table()
+    Base.metadata.create_all(
+        engine,
+        tables=[core_users, CallExport.__table__, CallRecord.__table__],
+    )
+
+    actor_id = uuid4()
+    with engine.begin() as conn:
+        conn.execute(insert(core_users).values(user_id=actor_id))
+
+    period_from = datetime(2024, 9, 1, tzinfo=timezone.utc)
+    period_to = period_from + timedelta(days=1)
+
+    with Session(engine) as session:
+        export = CallExport(
+            period_from=period_from,
+            period_to=period_to,
+            status=CallExportStatus.PENDING,
+            actor_user_id=actor_id,
+            options={"generate_summary": True},
+        )
+        session.add(export)
+        session.commit()
+        run_id: UUID = export.run_id
+        session.expunge_all()
+
+        loaded = session.get(CallExport, run_id)
+        assert loaded is not None
+        assert loaded.status is CallExportStatus.PENDING
+        assert loaded.period_from == period_from.replace(tzinfo=None)
+        assert loaded.period_to == period_to.replace(tzinfo=None)
+        assert loaded.actor_user_id == actor_id
+        assert loaded.options == {"generate_summary": True}
+
+        finished_at = period_to + timedelta(hours=1)
+        loaded.status = CallExportStatus.COMPLETED
+        loaded.finished_at = finished_at
+        session.commit()
+        session.expunge_all()
+
+        refreshed = session.get(CallExport, run_id)
+        assert refreshed is not None
+        assert refreshed.status is CallExportStatus.COMPLETED
+        assert refreshed.finished_at == finished_at.replace(tzinfo=None)
+
+        session.delete(refreshed)
+        session.commit()
+        assert session.get(CallExport, run_id) is None
+
+    engine.dispose()
+
+
+def test_call_record_crud_and_cascade() -> None:
+    """Ensure call records match schema constraints and cascade with exports."""
+
+    engine = _sqlite_engine()
+    core_users = _ensure_core_users_table()
+    Base.metadata.create_all(
+        engine,
+        tables=[core_users, CallExport.__table__, CallRecord.__table__],
+    )
+
+    period_from = datetime(2024, 9, 1, tzinfo=timezone.utc)
+    period_to = period_from + timedelta(days=1)
+
+    with Session(engine) as session:
+        export = CallExport(
+            period_from=period_from,
+            period_to=period_to,
+            status=CallExportStatus.PENDING,
+            options=None,
+        )
+        record = CallRecord(
+            export=export,
+            call_id="CALL-001",
+            duration_sec=180,
+            status=CallRecordStatus.PENDING,
+            transcript_lang="ru",
+        )
+        session.add_all([export, record])
+        session.commit()
+        run_id = export.run_id
+        record_id = record.id
+        session.expunge_all()
+
+        loaded = session.scalars(
+            select(CallRecord).where(CallRecord.id == record_id)
+        ).one()
+        assert loaded.run_id == run_id
+        assert loaded.call_id == "CALL-001"
+        assert loaded.record_id is None
+        assert loaded.duration_sec == 180
+        assert loaded.status is CallRecordStatus.PENDING
+        assert loaded.transcript_lang == "ru"
+        assert loaded.cost_currency == "RUB"
+
+        last_attempt = period_to + timedelta(hours=2)
+        loaded.status = CallRecordStatus.COMPLETED
+        loaded.attempts = 1
+        loaded.last_attempt_at = last_attempt
+        loaded.storage_path = "/storage/call-001.wav"
+        loaded.checksum = "abc123"
+        loaded.cost_amount = Decimal("12.34")
+        session.commit()
+        session.expunge_all()
+
+        updated = session.get(CallRecord, record_id)
+        assert updated is not None
+        assert updated.status is CallRecordStatus.COMPLETED
+        assert updated.attempts == 1
+        assert updated.last_attempt_at == last_attempt.replace(tzinfo=None)
+        assert updated.storage_path == "/storage/call-001.wav"
+        assert updated.checksum == "abc123"
+        assert updated.cost_amount == Decimal("12.34")
+        assert updated.cost_currency == "RUB"
+
+        duplicate = CallRecord(
+            run_id=run_id,
+            call_id="CALL-001",
+            duration_sec=60,
+            status=CallRecordStatus.PENDING,
+        )
+        session.add(duplicate)
+        with pytest.raises(IntegrityError):
+            session.commit()
+        session.rollback()
+
+        export_obj = session.get(CallExport, run_id)
+        assert export_obj is not None
+        session.delete(export_obj)
+        session.commit()
+        assert session.get(CallRecord, record_id) is None
+
+    engine.dispose()


### PR DESCRIPTION
## Summary
- add an Alembic migration that creates the call_exports and call_records tables with the documented checks, defaults, foreign keys, indexes, and unique constraint
- extend the ORM layer with enums and models for call exports and call records mirroring the migration schema
- add CRUD-style integration tests that exercise the new models against an in-memory SQLite database

## Testing
- PYTHONPATH=. pytest tests/test_db_models_integration_log.py tests/test_db_models_call_exports.py

------
https://chatgpt.com/codex/tasks/task_e_68d7cce2e708832aa4261551605ea1d6