### PR TITLE
feat: add Bitrix24 recording download workflow

### DIFF
--- a/apps/mw/src/integrations/b24/__init__.py
+++ b/apps/mw/src/integrations/b24/__init__.py
@@ -1,5 +1,6 @@
 """Bitrix24 integration helpers."""
 
 from .client import list_calls
+from .downloader import stream_recording
 
-__all__ = ["list_calls"]
+__all__ = ["list_calls", "stream_recording"]

--- a/apps/mw/src/integrations/b24/client.py
+++ b/apps/mw/src/integrations/b24/client.py
@@ -13,13 +13,13 @@ BITRIX24_ENDPOINT = "voximplant.statistic.get.json"
 MAX_RETRY_ATTEMPTS = 5
 
 
-def _build_request_url(base_url: str, user_id: int, token: str) -> str:
+def build_rest_method_url(base_url: str, user_id: int, token: str, method: str) -> str:
     """Return the fully-qualified Bitrix24 REST endpoint URL."""
 
     normalized = base_url.rstrip("/")
     if normalized.endswith("/rest"):
         normalized = normalized[: -len("/rest")]
-    return f"{normalized}/rest/{user_id}/{token}/{BITRIX24_ENDPOINT}"
+    return f"{normalized}/rest/{user_id}/{token}/{method}"
 
 
 def _coerce_datetime(value: str | datetime) -> str:
@@ -64,10 +64,11 @@ async def list_calls(date_from: str | datetime, date_to: str | datetime) -> list
     """Return all Voximplant calls between the provided dates."""
 
     settings = get_settings()
-    request_url = _build_request_url(
+    request_url = build_rest_method_url(
         settings.b24_base_url,
         settings.b24_webhook_user_id,
         settings.b24_webhook_token,
+        BITRIX24_ENDPOINT,
     )
 
     base_params = {

--- a/apps/mw/src/integrations/b24/downloader.py
+++ b/apps/mw/src/integrations/b24/downloader.py
@@ -1,0 +1,87 @@
+"""Utilities for downloading Bitrix24 call recordings."""
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+
+import httpx
+
+from apps.mw.src.config import get_settings
+
+from .client import MAX_RETRY_ATTEMPTS, build_rest_method_url
+
+RECORDING_ENDPOINT = "telephony.recording.get"
+
+
+def _compute_backoff_delay(base: float, attempt: int) -> float:
+    """Return exponential backoff delay for the given attempt index."""
+
+    if base <= 0:
+        return 0.0
+    return base * (2 ** (attempt - 1))
+
+
+async def stream_recording(call_id: str, record_id: str | None = None) -> AsyncIterator[bytes]:
+    """Yield chunks of a Bitrix24 call recording applying retry/backoff policy."""
+
+    settings = get_settings()
+    request_url = build_rest_method_url(
+        settings.b24_base_url,
+        settings.b24_webhook_user_id,
+        settings.b24_webhook_token,
+        RECORDING_ENDPOINT,
+    )
+
+    params: dict[str, str] = {"CALL_ID": call_id}
+    if record_id is not None:
+        params["RECORD_ID"] = record_id
+
+    backoff_base = float(settings.b24_backoff_seconds)
+
+    async with httpx.AsyncClient(timeout=float(settings.request_timeout_s)) as client:
+        attempt = 0
+        while True:
+            should_retry = False
+            delay = 0.0
+            try:
+                async with client.stream("GET", request_url, params=params) as response:
+                    if response.status_code == httpx.codes.OK:
+                        try:
+                            async for chunk in response.aiter_bytes():
+                                if chunk:
+                                    yield chunk
+                            return
+                        except httpx.HTTPError:
+                            attempt += 1
+                            if attempt >= MAX_RETRY_ATTEMPTS:
+                                raise
+                            delay = _compute_backoff_delay(backoff_base, attempt)
+                            should_retry = True
+                    elif (
+                        response.status_code == httpx.codes.TOO_MANY_REQUESTS
+                        or 500 <= response.status_code < 600
+                    ):
+                        attempt += 1
+                        if attempt >= MAX_RETRY_ATTEMPTS:
+                            response.raise_for_status()
+                        delay = _compute_backoff_delay(backoff_base, attempt)
+                        should_retry = True
+                    else:
+                        response.raise_for_status()
+                        return
+            except httpx.RequestError:
+                attempt += 1
+                if attempt >= MAX_RETRY_ATTEMPTS:
+                    raise
+                delay = _compute_backoff_delay(backoff_base, attempt)
+                should_retry = True
+
+            if should_retry:
+                if delay > 0:
+                    await asyncio.sleep(delay)
+                continue
+
+            # If we reach this point it means the response raised a non-retryable
+            # error and the exception has already been propagated.
+            return
+

--- a/apps/mw/src/services/__init__.py
+++ b/apps/mw/src/services/__init__.py
@@ -1,0 +1,6 @@
+"""Service layer helpers for the middleware application."""
+
+from .call_download import download_call_record
+from .storage import StorageResult, StorageService
+
+__all__ = ["download_call_record", "StorageResult", "StorageService"]

--- a/apps/mw/src/services/call_download.py
+++ b/apps/mw/src/services/call_download.py
@@ -1,0 +1,92 @@
+"""Workflow helpers for downloading Bitrix24 call recordings."""
+from __future__ import annotations
+
+import logging
+from collections.abc import AsyncIterable
+from datetime import datetime, timezone
+from typing import Callable
+
+import httpx
+
+from apps.mw.src.db.models import CallRecord, CallRecordStatus
+from apps.mw.src.integrations.b24.client import MAX_RETRY_ATTEMPTS
+from apps.mw.src.integrations.b24.downloader import stream_recording
+from apps.mw.src.services.storage import StorageResult, StorageService
+
+logger = logging.getLogger(__name__)
+
+
+RecordingStreamFactory = Callable[[str, str | None], AsyncIterable[bytes]]
+
+
+async def download_call_record(
+    record: CallRecord,
+    *,
+    storage: StorageService | None = None,
+    stream_factory: RecordingStreamFactory = stream_recording,
+) -> StorageResult | None:
+    """Download a call recording and persist it using the configured storage backend."""
+
+    if record.storage_path and record.checksum:
+        logger.info(
+            "Call %s already downloaded; skipping", record.call_id
+        )
+        return None
+
+    if record.attempts >= MAX_RETRY_ATTEMPTS:
+        record.status = CallRecordStatus.ERROR
+        record.error_code = "max_attempts"
+        record.error_message = "Maximum download attempts exceeded"
+        record.last_attempt_at = datetime.now(tz=timezone.utc)
+        logger.error(
+            "Call %s exceeded retry limit; attempts=%s", record.call_id, record.attempts
+        )
+        raise RuntimeError("maximum download attempts exceeded")
+
+    storage = storage or StorageService()
+
+    record.status = CallRecordStatus.DOWNLOADING
+    record.attempts += 1
+    record.last_attempt_at = datetime.now(tz=timezone.utc)
+    logger.info("Starting download for call %s", record.call_id)
+
+    try:
+        stream = stream_factory(record.call_id, record.record_id)
+        result = await storage.store_call_recording(
+            record.call_id,
+            stream,
+            started_at=record.call_started_at,
+        )
+    except httpx.HTTPStatusError as exc:  # pragma: no cover - defensive guard
+        _handle_failure(record, f"http_{exc.response.status_code}", str(exc))
+        raise
+    except httpx.HTTPError as exc:
+        _handle_failure(record, exc.__class__.__name__, str(exc))
+        raise
+    except Exception as exc:  # pragma: no cover - defensive guard
+        _handle_failure(record, exc.__class__.__name__, str(exc))
+        raise
+
+    record.storage_path = result.path
+    record.checksum = result.checksum
+    record.status = CallRecordStatus.DOWNLOADED
+    record.error_code = None
+    record.error_message = None
+
+    logger.info(
+        "Finished download for call %s (backend=%s, bytes=%s)",
+        record.call_id,
+        result.backend,
+        result.bytes_stored,
+    )
+
+    return result
+
+
+def _handle_failure(record: CallRecord, code: str, message: str) -> None:
+    record.status = CallRecordStatus.ERROR
+    record.error_code = code
+    record.error_message = message
+    logger.error(
+        "Failed to download call %s (attempt=%s): %s", record.call_id, record.attempts, message
+    )

--- a/apps/mw/src/services/storage.py
+++ b/apps/mw/src/services/storage.py
@@ -1,0 +1,123 @@
+"""Storage service abstraction for call recordings."""
+from __future__ import annotations
+
+import hashlib
+from collections.abc import AsyncIterable
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Literal
+
+import boto3
+
+from apps.mw.src.config import get_settings
+from apps.mw.src.config.settings import Settings
+
+
+@dataclass(slots=True)
+class StorageResult:
+    """Metadata about a stored recording."""
+
+    path: str
+    checksum: str
+    backend: Literal["local", "s3"]
+    bytes_stored: int
+
+
+class StorageService:
+    """Persist Bitrix24 recordings to the configured storage backend."""
+
+    def __init__(self, settings: Settings | None = None, *, s3_client: Any | None = None) -> None:
+        self._settings = settings or get_settings()
+        self._backend = self._settings.storage_backend
+        self._s3_client = s3_client
+        if self._backend == "s3" and not self._settings.s3_bucket:
+            raise ValueError("S3 bucket must be configured for S3 storage backend")
+
+    async def store_call_recording(
+        self,
+        call_id: str,
+        stream: AsyncIterable[bytes],
+        *,
+        started_at: datetime | None,
+    ) -> StorageResult:
+        """Persist the incoming recording stream and return its metadata."""
+
+        key = self._build_object_key(call_id, started_at)
+
+        if self._backend == "s3":
+            return await self._store_s3(key, stream)
+
+        return await self._store_local(key, stream)
+
+    async def _store_local(self, key: str, stream: AsyncIterable[bytes]) -> StorageResult:
+        storage_root = Path(self._settings.local_storage_dir)
+        storage_root.mkdir(parents=True, exist_ok=True)
+
+        destination = storage_root / key
+        destination.parent.mkdir(parents=True, exist_ok=True)
+
+        digest = hashlib.sha256()
+        bytes_written = 0
+
+        with destination.open("wb") as handle:
+            async for chunk in stream:
+                handle.write(chunk)
+                digest.update(chunk)
+                bytes_written += len(chunk)
+
+        return StorageResult(
+            path=str(destination),
+            checksum=digest.hexdigest(),
+            backend="local",
+            bytes_stored=bytes_written,
+        )
+
+    async def _store_s3(self, key: str, stream: AsyncIterable[bytes]) -> StorageResult:
+        client = self._s3_client or self._create_s3_client()
+        digest = hashlib.sha256()
+        payload = bytearray()
+
+        bytes_written = 0
+        async for chunk in stream:
+            payload.extend(chunk)
+            digest.update(chunk)
+            bytes_written += len(chunk)
+
+        client.put_object(
+            Bucket=self._settings.s3_bucket,
+            Key=key,
+            Body=bytes(payload),
+        )
+
+        return StorageResult(
+            path=f"s3://{self._settings.s3_bucket}/{key}",
+            checksum=digest.hexdigest(),
+            backend="s3",
+            bytes_stored=bytes_written,
+        )
+
+    def _build_object_key(self, call_id: str, started_at: datetime | None) -> str:
+        if started_at is not None:
+            if started_at.tzinfo is None:
+                started_at = started_at.replace(tzinfo=timezone.utc)
+            day = started_at.astimezone(timezone.utc).date()
+        else:
+            day = datetime.now(tz=timezone.utc).date()
+
+        return str(
+            Path("raw")
+            / f"{day.year:04d}"
+            / f"{day.month:02d}"
+            / f"{day.day:02d}"
+            / f"call_{call_id}.mp3"
+        )
+
+    def _create_s3_client(self) -> Any:
+        return boto3.client(
+            "s3",
+            endpoint_url=self._settings.s3_endpoint_url,
+            region_name=self._settings.s3_region,
+            aws_access_key_id=self._settings.s3_access_key_id,
+            aws_secret_access_key=self._settings.s3_secret_access_key,
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,8 @@ dependencies = [
     "redis>=5.0",
     "python-dotenv>=1.0",
     "loguru>=0.7",
-    "python-multipart>=0.0.9"
+    "python-multipart>=0.0.9",
+    "boto3>=1.34"
 ]
 
 [project.optional-dependencies]

--- a/tests/test_b24_download.py
+++ b/tests/test_b24_download.py
@@ -1,0 +1,235 @@
+"""Tests for Bitrix24 recording download workflow."""
+from __future__ import annotations
+
+import hashlib
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import boto3
+import httpx
+import pytest
+from botocore.stub import Stubber
+
+from apps.mw.src.config.settings import get_settings
+from apps.mw.src.db.models import CallRecord, CallRecordStatus
+from apps.mw.src.integrations.b24 import stream_recording
+from apps.mw.src.integrations.b24.client import MAX_RETRY_ATTEMPTS
+from apps.mw.src.services.call_download import download_call_record
+from apps.mw.src.services.storage import StorageService
+
+
+@pytest.fixture(autouse=True)
+def configure_environment(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Configure defaults for Bitrix24 and storage related settings."""
+
+    monkeypatch.setenv("B24_BASE_URL", "https://example.bitrix24.ru/rest")
+    monkeypatch.setenv("B24_WEBHOOK_USER_ID", "1")
+    monkeypatch.setenv("B24_WEBHOOK_TOKEN", "token")
+    monkeypatch.setenv("B24_RATE_LIMIT_RPS", "2")
+    monkeypatch.setenv("B24_BACKOFF_SECONDS", "5")
+    monkeypatch.setenv("LOCAL_STORAGE_DIR", str(tmp_path))
+    monkeypatch.setenv("STORAGE_BACKEND", "local")
+
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture
+def sleep_mock(monkeypatch: pytest.MonkeyPatch) -> AsyncMock:
+    """Patch asyncio.sleep in the downloader to avoid real delays."""
+
+    mock = AsyncMock()
+    monkeypatch.setattr("apps.mw.src.integrations.b24.downloader.asyncio.sleep", mock)
+    return mock
+
+
+def _call_record(status: CallRecordStatus = CallRecordStatus.PENDING) -> CallRecord:
+    return CallRecord(
+        run_id=uuid4(),
+        call_id="42",
+        record_id="1001",
+        call_started_at=datetime(2024, 9, 1, 12, 0, tzinfo=timezone.utc),
+        duration_sec=120,
+        recording_url=None,
+        storage_path=None,
+        transcript_path=None,
+        transcript_lang=None,
+        checksum=None,
+        status=status,
+        attempts=0,
+    )
+
+
+@pytest.mark.asyncio
+async def test_stream_recording_retries_and_streams_bytes(
+    respx_mock: "respx.MockRouter", sleep_mock: AsyncMock
+) -> None:
+    """Downloader applies retry/backoff logic and yields streamed data."""
+
+    url = "https://example.bitrix24.ru/rest/1/token/telephony.recording.get"
+    route = respx_mock.get(url).mock(
+        side_effect=[
+            httpx.Response(429, json={"error": "Too many requests"}),
+            httpx.Response(200, content=b"audio-bytes"),
+        ]
+    )
+
+    chunks = [chunk async for chunk in stream_recording("42")]
+    data = b"".join(chunks)
+
+    assert data == b"audio-bytes"
+    assert route.call_count == 2
+    assert sleep_mock.await_count == 1
+    assert sleep_mock.await_args_list[0].args[0] == pytest.approx(5.0)
+
+
+@pytest.mark.asyncio
+async def test_storage_local_persists_file_with_checksum(tmp_path: Path) -> None:
+    """Local backend writes a deterministic path and computes checksum."""
+
+    settings = get_settings()
+    service = StorageService(settings=settings)
+
+    async def generator():
+        yield b"hello-world"
+
+    result = await service.store_call_recording(
+        "abc",
+        generator(),
+        started_at=datetime(2024, 9, 2, 15, 30, tzinfo=timezone.utc),
+    )
+
+    expected_path = (
+        Path(settings.local_storage_dir)
+        / "raw"
+        / "2024"
+        / "09"
+        / "02"
+        / "call_abc.mp3"
+    )
+
+    assert Path(result.path) == expected_path
+    assert expected_path.exists()
+    assert expected_path.read_bytes() == b"hello-world"
+    assert result.checksum == hashlib.sha256(b"hello-world").hexdigest()
+
+
+@pytest.mark.asyncio
+async def test_download_workflow_updates_status_and_checksum(
+    respx_mock: "respx.MockRouter",
+) -> None:
+    """Successful download transitions the record and stores metadata."""
+
+    record = _call_record()
+
+    url = "https://example.bitrix24.ru/rest/1/token/telephony.recording.get"
+    respx_mock.get(url).mock(return_value=httpx.Response(200, content=b"binary-audio"))
+
+    storage = StorageService(settings=get_settings())
+    result = await download_call_record(record, storage=storage)
+
+    assert result is not None
+    assert record.status is CallRecordStatus.DOWNLOADED
+    assert record.storage_path is not None
+    assert Path(record.storage_path).exists()
+    assert record.checksum == hashlib.sha256(b"binary-audio").hexdigest()
+    assert record.attempts == 1
+    assert record.error_code is None
+    assert record.error_message is None
+
+
+@pytest.mark.asyncio
+async def test_download_workflow_skips_when_already_downloaded(
+    respx_mock: "respx.MockRouter",
+) -> None:
+    """Existing storage path and checksum prevent duplicate downloads."""
+
+    record = _call_record(status=CallRecordStatus.DOWNLOADED)
+    record.storage_path = "/tmp/fake.mp3"
+    record.checksum = "deadbeef"
+    record.attempts = 3
+
+    url = "https://example.bitrix24.ru/rest/1/token/telephony.recording.get"
+    route = respx_mock.get(url).mock(return_value=httpx.Response(200, content=b"unused"))
+
+    result = await download_call_record(record, storage=StorageService(settings=get_settings()))
+
+    assert result is None
+    assert route.call_count == 0
+    assert record.attempts == 3
+    assert record.status is CallRecordStatus.DOWNLOADED
+
+
+@pytest.mark.asyncio
+async def test_download_workflow_respects_retry_limit(
+    respx_mock: "respx.MockRouter",
+) -> None:
+    """Records stop processing once the maximum retry limit is reached."""
+
+    record = _call_record()
+    record.attempts = MAX_RETRY_ATTEMPTS
+
+    url = "https://example.bitrix24.ru/rest/1/token/telephony.recording.get"
+    route = respx_mock.get(url).mock(return_value=httpx.Response(200, content=b"unused"))
+
+    with pytest.raises(RuntimeError):
+        await download_call_record(record, storage=StorageService(settings=get_settings()))
+
+    assert route.call_count == 0
+    assert record.status is CallRecordStatus.ERROR
+    assert record.error_code == "max_attempts"
+
+
+@pytest.mark.asyncio
+async def test_storage_s3_backend_uses_configured_bucket(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """S3 backend uploads to the configured bucket and returns metadata."""
+
+    monkeypatch.setenv("STORAGE_BACKEND", "s3")
+    monkeypatch.setenv("S3_BUCKET", "test-bucket")
+    monkeypatch.setenv("S3_REGION", "us-east-1")
+    monkeypatch.setenv("S3_ACCESS_KEY_ID", "key")
+    monkeypatch.setenv("S3_SECRET_ACCESS_KEY", "secret")
+    get_settings.cache_clear()
+
+    client = boto3.client(
+        "s3",
+        region_name="us-east-1",
+        aws_access_key_id="key",
+        aws_secret_access_key="secret",
+    )
+    stubber = Stubber(client)
+
+    expected_key = "raw/2024/09/01/call_42.mp3"
+    stubber.add_response(
+        "put_object",
+        {},
+        {
+            "Bucket": "test-bucket",
+            "Key": expected_key,
+            "Body": b"cloud-bytes",
+        },
+    )
+
+    stubber.activate()
+
+    service = StorageService(settings=get_settings(), s3_client=client)
+
+    async def generator():
+        yield b"cloud-bytes"
+
+    result = await service.store_call_recording(
+        "42",
+        generator(),
+        started_at=datetime(2024, 9, 1, tzinfo=timezone.utc),
+    )
+
+    stubber.deactivate()
+    stubber.assert_no_pending_responses()
+    assert result.path == "s3://test-bucket/raw/2024/09/01/call_42.mp3"
+    assert result.checksum == hashlib.sha256(b"cloud-bytes").hexdigest()
+    assert result.backend == "s3"


### PR DESCRIPTION
## Summary
- add a Bitrix24 recording downloader that streams `telephony.recording.get` with the same retry/backoff policy used by call listing
- introduce a storage service to persist streamed MP3s to the local filesystem or S3 with deterministic paths and checksums while updating the download workflow
- cover the new behaviour with async tests for retry limits, storage layout, checksum stability, and backend selection

## Testing
- `pytest tests/test_b24_download.py`
- `pytest tests/test_b24_list_calls.py`


------
https://chatgpt.com/codex/tasks/task_e_68d7d3979a44832a9f5636e4cae3144a