### PR TITLE
feat: capture call direction and numbers

### DIFF
--- a/apps/mw/migrations/versions/0004_call_records_direction_and_numbers.py
+++ b/apps/mw/migrations/versions/0004_call_records_direction_and_numbers.py
@@ -1,0 +1,90 @@
+"""Add direction and phone numbers to call records."""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "0004_call_records_direction_and_numbers"
+down_revision = "0003_call_exports_call_records"
+branch_labels = None
+depends_on = None
+
+
+CALL_RECORD_DIRECTION_CHECK = (
+    "direction IN ('inbound','outbound','internal')"
+)
+CALL_RECORD_FROM_NUMBER_CHECK = "length(trim(from_number)) > 0"
+CALL_RECORD_TO_NUMBER_CHECK = "length(trim(to_number)) > 0"
+
+
+def upgrade() -> None:
+    op.add_column(
+        "call_records",
+        sa.Column(
+            "direction",
+            sa.Text(),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "call_records",
+        sa.Column(
+            "from_number",
+            sa.Text(),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "call_records",
+        sa.Column(
+            "to_number",
+            sa.Text(),
+            nullable=True,
+        ),
+    )
+
+    op.execute("UPDATE call_records SET direction = 'inbound' WHERE direction IS NULL")
+    op.execute("UPDATE call_records SET from_number = 'unknown' WHERE from_number IS NULL")
+    op.execute("UPDATE call_records SET to_number = 'unknown' WHERE to_number IS NULL")
+
+    op.alter_column("call_records", "direction", nullable=False)
+    op.alter_column("call_records", "from_number", nullable=False)
+    op.alter_column("call_records", "to_number", nullable=False)
+
+    op.create_check_constraint(
+        "chk_call_records_direction",
+        "call_records",
+        CALL_RECORD_DIRECTION_CHECK,
+    )
+    op.create_check_constraint(
+        "chk_call_records_from_number_not_blank",
+        "call_records",
+        CALL_RECORD_FROM_NUMBER_CHECK,
+    )
+    op.create_check_constraint(
+        "chk_call_records_to_number_not_blank",
+        "call_records",
+        CALL_RECORD_TO_NUMBER_CHECK,
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "chk_call_records_to_number_not_blank",
+        "call_records",
+        type_="check",
+    )
+    op.drop_constraint(
+        "chk_call_records_from_number_not_blank",
+        "call_records",
+        type_="check",
+    )
+    op.drop_constraint(
+        "chk_call_records_direction",
+        "call_records",
+        type_="check",
+    )
+    op.drop_column("call_records", "to_number")
+    op.drop_column("call_records", "from_number")
+    op.drop_column("call_records", "direction")

--- a/apps/mw/src/db/models.py
+++ b/apps/mw/src/db/models.py
@@ -102,6 +102,14 @@ class CallRecordStatus(str, Enum):
     ERROR = "error"
 
 
+class CallDirection(str, Enum):
+    """Direction of a Bitrix24 call."""
+
+    INBOUND = "inbound"
+    OUTBOUND = "outbound"
+    INTERNAL = "internal"
+
+
 JSONBType = JSONB().with_variant(SQLiteJSON(), "sqlite")
 
 
@@ -352,6 +360,18 @@ class CallRecord(Base):
             "status IN ('pending','downloading','downloaded','transcribing','completed','skipped','error')",
             name="chk_call_records_status",
         ),
+        CheckConstraint(
+            "direction IN ('inbound','outbound','internal')",
+            name="chk_call_records_direction",
+        ),
+        CheckConstraint(
+            "length(trim(from_number)) > 0",
+            name="chk_call_records_from_number_not_blank",
+        ),
+        CheckConstraint(
+            "length(trim(to_number)) > 0",
+            name="chk_call_records_to_number_not_blank",
+        ),
         Index(
             "idx_call_records_status_run",
             "status",
@@ -385,6 +405,12 @@ class CallRecord(Base):
         nullable=False,
     )
     call_id: Mapped[str] = mapped_column(Text, nullable=False)
+    direction: Mapped[CallDirection] = mapped_column(
+        _enum_type(CallDirection, name="call_direction", length=16),
+        nullable=False,
+    )
+    from_number: Mapped[str] = mapped_column(Text, nullable=False)
+    to_number: Mapped[str] = mapped_column(Text, nullable=False)
     record_id: Mapped[str | None] = mapped_column(Text, nullable=True)
     call_started_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True),

--- a/tests/test_db_models_call_exports.py
+++ b/tests/test_db_models_call_exports.py
@@ -16,6 +16,7 @@ from apps.mw.src.db.models import (
     Base,
     CallExport,
     CallExportStatus,
+    CallDirection,
     CallRecord,
     CallRecordStatus,
 )
@@ -122,6 +123,9 @@ def test_call_record_crud_and_cascade() -> None:
         record = CallRecord(
             export=export,
             call_id="CALL-001",
+            direction=CallDirection.INBOUND,
+            from_number="+74951234567",
+            to_number="+79997654321",
             duration_sec=180,
             status=CallRecordStatus.PENDING,
             transcript_lang="ru",
@@ -137,6 +141,9 @@ def test_call_record_crud_and_cascade() -> None:
         ).one()
         assert loaded.run_id == run_id
         assert loaded.call_id == "CALL-001"
+        assert loaded.direction is CallDirection.INBOUND
+        assert loaded.from_number == "+74951234567"
+        assert loaded.to_number == "+79997654321"
         assert loaded.record_id is None
         assert loaded.duration_sec == 180
         assert loaded.status is CallRecordStatus.PENDING
@@ -150,6 +157,9 @@ def test_call_record_crud_and_cascade() -> None:
         loaded.storage_path = "/storage/call-001.wav"
         loaded.checksum = "abc123"
         loaded.cost_amount = Decimal("12.34")
+        loaded.direction = CallDirection.OUTBOUND
+        loaded.from_number = "+74959876543"
+        loaded.to_number = "+78005553535"
         session.commit()
         session.expunge_all()
 
@@ -162,10 +172,16 @@ def test_call_record_crud_and_cascade() -> None:
         assert updated.checksum == "abc123"
         assert updated.cost_amount == Decimal("12.34")
         assert updated.cost_currency == "RUB"
+        assert updated.direction is CallDirection.OUTBOUND
+        assert updated.from_number == "+74959876543"
+        assert updated.to_number == "+78005553535"
 
         duplicate = CallRecord(
             run_id=run_id,
             call_id="CALL-001",
+            direction=CallDirection.OUTBOUND,
+            from_number="+74951230000",
+            to_number="+78001230000",
             duration_sec=60,
             status=CallRecordStatus.PENDING,
         )


### PR DESCRIPTION
## Summary
- add direction, from_number, and to_number fields to the CallRecord ORM model with validation constraints
- create an Alembic migration to backfill call records and enforce the new columns at the database level
- extend call export tests to exercise CRUD around the new call record fields

## Testing
- PYTHONPATH=. pytest tests/test_db_models_call_exports.py

------
https://chatgpt.com/codex/tasks/task_e_68d7d4b0a3d0832aa5ac84a42e84d76b