### PR TITLE
feat: add call registry CSV export endpoint

### DIFF
--- a/apps/mw/src/api/routes/call_registry.py
+++ b/apps/mw/src/api/routes/call_registry.py
@@ -1,0 +1,132 @@
+"""Endpoints for exporting Bitrix24 call registry CSV reports."""
+from __future__ import annotations
+
+import csv
+from collections.abc import Iterable
+from datetime import datetime
+from io import StringIO
+
+from fastapi import APIRouter, Depends, Query, Response, status
+from fastapi.responses import StreamingResponse
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from apps.mw.src.api.dependencies import ProblemDetailException, build_error, provide_request_id
+from apps.mw.src.db.models import CallRecord
+from apps.mw.src.db.session import get_session
+
+_CSV_HEADERS = [
+    "datetime_start",
+    "direction",
+    "from",
+    "to",
+    "duration_sec",
+    "recording_url",
+    "status",
+]
+
+router = APIRouter(
+    prefix="/api/v1/call-registry",
+    tags=["call-registry"],
+    dependencies=[Depends(provide_request_id)],
+)
+
+
+def _format_datetime(value: datetime | None) -> str:
+    """Render datetimes in ISO-8601 format (empty string when missing)."""
+
+    if value is None:
+        return ""
+    return value.isoformat()
+
+
+def _encode_row(values: list[str], *, include_bom: bool = False) -> bytes:
+    """Serialize a CSV row with semicolon delimiter and optional BOM."""
+
+    buffer = StringIO()
+    writer = csv.writer(buffer, delimiter=";", lineterminator="\r\n", quoting=csv.QUOTE_MINIMAL)
+    writer.writerow(values)
+    payload = buffer.getvalue()
+    if include_bom:
+        payload = "\ufeff" + payload
+    return payload.encode("utf-8")
+
+
+def _row_values(record: CallRecord) -> list[str]:
+    """Extract CSV field values from a call record."""
+
+    direction = getattr(record, "direction", None)
+    from_number = getattr(record, "from_number", None)
+    to_number = getattr(record, "to_number", None)
+    status = record.status.value if hasattr(record.status, "value") else str(record.status)
+
+    return [
+        _format_datetime(getattr(record, "call_started_at", None)),
+        direction or "",
+        from_number or "",
+        to_number or "",
+        str(record.duration_sec),
+        record.recording_url or "",
+        status,
+    ]
+
+
+def _stream_csv(rows: Iterable[CallRecord]) -> Iterable[bytes]:
+    """Yield the call registry CSV as UTF-8 encoded chunks."""
+
+    yield _encode_row(_CSV_HEADERS, include_bom=True)
+    for record in rows:
+        yield _encode_row(_row_values(record))
+
+
+@router.get(
+    "",
+    summary="Download call registry CSV",
+    response_class=StreamingResponse,
+    responses={
+        status.HTTP_400_BAD_REQUEST: {
+            "description": "Invalid period range.",
+        }
+    },
+)
+def export_call_registry(
+    response: Response,
+    period_from: datetime = Query(..., description="Start of the call start timestamp range."),
+    period_to: datetime = Query(..., description="End of the call start timestamp range."),
+    session: Session = Depends(get_session),
+) -> StreamingResponse:
+    """Stream a semicolon-separated CSV of call records for the requested period."""
+
+    if period_to < period_from:
+        error = build_error(
+            status.HTTP_400_BAD_REQUEST,
+            title="Invalid period range",
+            detail="period_to must be greater than or equal to period_from.",
+            request_id=response.headers.get("X-Request-Id"),
+        )
+        raise ProblemDetailException(error)
+
+    stmt = (
+        select(CallRecord)
+        .where(CallRecord.call_started_at.isnot(None))
+        .where(CallRecord.call_started_at >= period_from)
+        .where(CallRecord.call_started_at <= period_to)
+        .order_by(CallRecord.call_started_at.asc(), CallRecord.id.asc())
+    )
+    rows = session.scalars(stmt).all()
+
+    filename = (
+        f"call_registry_{period_from.strftime('%Y%m%dT%H%M%S')}"
+        f"_{period_to.strftime('%Y%m%dT%H%M%S')}.csv"
+    )
+
+    stream = _stream_csv(rows)
+    streaming_response = StreamingResponse(stream, media_type="text/csv; charset=utf-8")
+    streaming_response.headers["Content-Disposition"] = f'attachment; filename="{filename}"'
+    streaming_response.headers.setdefault("Cache-Control", "no-store")
+
+    request_id = response.headers.get("X-Request-Id")
+    if request_id:
+        streaming_response.headers["X-Request-Id"] = request_id
+
+    return streaming_response

--- a/apps/mw/src/app.py
+++ b/apps/mw/src/app.py
@@ -13,6 +13,7 @@ from apps.mw.src.api.dependencies import (
     build_error,
     provide_request_id,
 )
+from apps.mw.src.api.routes import call_registry as call_registry_router
 from apps.mw.src.api.routes import returns as returns_router
 from apps.mw.src.api.routes import system as system_router
 from apps.mw.src.api.schemas import Error, Health
@@ -21,6 +22,7 @@ from apps.mw.src.health import get_health_payload
 app = FastAPI(title="MasterMobile MW")
 
 app.include_router(system_router.router)
+app.include_router(call_registry_router.router)
 app.include_router(returns_router.router)
 
 

--- a/apps/mw/src/db/models.py
+++ b/apps/mw/src/db/models.py
@@ -390,6 +390,9 @@ class CallRecord(Base):
         DateTime(timezone=True),
         nullable=True,
     )
+    direction: Mapped[str | None] = mapped_column(String(16), nullable=True)
+    from_number: Mapped[str | None] = mapped_column(Text, nullable=True)
+    to_number: Mapped[str | None] = mapped_column(Text, nullable=True)
     duration_sec: Mapped[int] = mapped_column(Integer, nullable=False)
     recording_url: Mapped[str | None] = mapped_column(Text, nullable=True)
     storage_path: Mapped[str | None] = mapped_column(Text, nullable=True)

--- a/tests/test_call_registry_api.py
+++ b/tests/test_call_registry_api.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import codecs
+from datetime import datetime, timedelta
+
+import httpx
+import pytest
+import pytest_asyncio
+from sqlalchemy import Column, Table, create_engine
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import Session
+from sqlalchemy.pool import StaticPool
+from sqlalchemy.dialects.postgresql import UUID as PGUUID
+
+from apps.mw.src.app import app
+from apps.mw.src.db.models import (
+    Base,
+    CallExport,
+    CallExportStatus,
+    CallRecord,
+    CallRecordStatus,
+)
+from apps.mw.src.db.session import configure_engine, engine as default_engine, get_session
+
+BASE_URL = "http://testserver"
+
+
+def _ensure_core_users_table() -> Table:
+    if "core.users" not in Base.metadata.tables:
+        return Table(
+            "core.users",
+            Base.metadata,
+            Column("user_id", PGUUID(as_uuid=True), primary_key=True),
+        )
+    return Base.metadata.tables["core.users"]
+
+
+@pytest.fixture()
+def sqlite_engine() -> Engine:
+    engine = create_engine(
+        "sqlite+pysqlite:///:memory:",
+        future=True,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    core_users = _ensure_core_users_table()
+    Base.metadata.create_all(
+        engine,
+        tables=[core_users, CallExport.__table__, CallRecord.__table__],
+    )
+    configure_engine(engine)
+    yield engine
+    configure_engine(default_engine)
+    engine.dispose()
+
+
+@pytest_asyncio.fixture()
+async def api_client(sqlite_engine: Engine) -> httpx.AsyncClient:
+    def override_get_session() -> Session:
+        session = Session(bind=sqlite_engine)
+        try:
+            yield session
+        finally:
+            session.close()
+
+    app.dependency_overrides[get_session] = override_get_session
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url=BASE_URL) as client:
+        yield client
+    app.dependency_overrides.pop(get_session, None)
+
+
+def _seed_call_records(engine: Engine) -> None:
+    period_from = datetime(2024, 1, 1, 0, 0, 0)
+    period_to = period_from + timedelta(days=1)
+
+    with Session(engine) as session:
+        export = CallExport(
+            period_from=period_from,
+            period_to=period_to,
+            status=CallExportStatus.COMPLETED,
+        )
+        in_range = CallRecord(
+            export=export,
+            call_id="CALL-001",
+            record_id="REC-001",
+            call_started_at=datetime(2024, 1, 1, 10, 30, 0),
+            direction="inbound",
+            from_number="+700000001",
+            to_number="+700000002",
+            duration_sec=180,
+            recording_url="https://example.com/records/1.mp3",
+            status=CallRecordStatus.COMPLETED,
+        )
+        out_of_range = CallRecord(
+            export=export,
+            call_id="CALL-002",
+            record_id="REC-002",
+            call_started_at=datetime(2024, 1, 2, 12, 0, 0),
+            direction="outbound",
+            from_number="+700000003",
+            to_number="+700000004",
+            duration_sec=60,
+            recording_url="https://example.com/records/2.mp3",
+            status=CallRecordStatus.COMPLETED,
+        )
+        session.add_all([export, in_range, out_of_range])
+        session.commit()
+
+
+@pytest.mark.asyncio
+async def test_export_call_registry_streams_csv(
+    api_client: httpx.AsyncClient,
+    sqlite_engine: Engine,
+) -> None:
+    _seed_call_records(sqlite_engine)
+
+    response = await api_client.get(
+        "/api/v1/call-registry",
+        params={
+            "period_from": "2024-01-01T00:00:00",
+            "period_to": "2024-01-01T23:59:59",
+        },
+        headers={"X-Request-Id": "req-call-registry-1"},
+    )
+
+    assert response.status_code == 200
+    assert response.headers["Content-Type"].startswith("text/csv")
+    assert response.headers["X-Request-Id"] == "req-call-registry-1"
+    assert response.headers["Content-Disposition"].endswith('.csv"')
+
+    content = response.content
+    assert content.startswith(codecs.BOM_UTF8)
+    decoded = content.decode("utf-8-sig")
+    lines = [line for line in decoded.splitlines() if line]
+    assert lines[0] == "datetime_start;direction;from;to;duration_sec;recording_url;status"
+    assert lines[1] == (
+        "2024-01-01T10:30:00;inbound;+700000001;+700000002;180;"
+        "https://example.com/records/1.mp3;completed"
+    )
+    assert len(lines) == 2
+
+
+@pytest.mark.asyncio
+async def test_export_call_registry_validates_period(
+    api_client: httpx.AsyncClient,
+) -> None:
+    response = await api_client.get(
+        "/api/v1/call-registry",
+        params={
+            "period_from": "2024-01-02T00:00:00",
+            "period_to": "2024-01-01T00:00:00",
+        },
+        headers={"X-Request-Id": "req-call-registry-2"},
+    )
+
+    assert response.status_code == 400
+    payload = response.json()
+    assert payload["title"] == "Invalid period range"
+    assert payload["status"] == 400


### PR DESCRIPTION
## Summary
- add a call registry router that streams call records as a semicolon-delimited CSV with Excel-friendly headers
- register the router in the FastAPI app and extend `CallRecord` with phone metadata columns
- seed and exercise the new export via API tests and ensure the test harness loads the real httpx transport

## Testing
- PYTHONPATH=. pytest tests/test_call_registry_api.py

------
https://chatgpt.com/codex/tasks/task_e_68d7d4b1bb60832a9e9c5fe26122df31