### PR TITLE
feat: support missing audio call record status

### DIFF
--- a/apps/mw/migrations/versions/0003_call_exports_call_records.py
+++ b/apps/mw/migrations/versions/0003_call_exports_call_records.py
@@ -17,7 +17,7 @@ CALL_EXPORT_STATUS_CHECK = (
 )
 
 CALL_RECORD_STATUS_CHECK = (
-    "status IN ('pending','downloading','downloaded','transcribing','completed','skipped','error')"
+    "status IN ('pending','downloading','downloaded','transcribing','completed','skipped','error','missing_audio')"
 )
 
 

--- a/apps/mw/migrations/versions/0004_call_records_missing_audio.py
+++ b/apps/mw/migrations/versions/0004_call_records_missing_audio.py
@@ -1,0 +1,37 @@
+"""Allow missing_audio status in call_records CHECK constraint."""
+
+from __future__ import annotations
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0004_call_records_missing_audio"
+down_revision = "0003_call_exports_call_records"
+branch_labels = None
+depends_on = None
+
+CALL_RECORD_STATUS_CHECK = (
+    "status IN ('pending','downloading','downloaded','transcribing','completed','skipped','error','missing_audio')"
+)
+
+PREVIOUS_CALL_RECORD_STATUS_CHECK = (
+    "status IN ('pending','downloading','downloaded','transcribing','completed','skipped','error')"
+)
+
+
+def upgrade() -> None:
+    op.drop_constraint("chk_call_records_status", "call_records", type_="check")
+    op.create_check_constraint(
+        "chk_call_records_status",
+        "call_records",
+        CALL_RECORD_STATUS_CHECK,
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("chk_call_records_status", "call_records", type_="check")
+    op.create_check_constraint(
+        "chk_call_records_status",
+        "call_records",
+        PREVIOUS_CALL_RECORD_STATUS_CHECK,
+    )

--- a/apps/mw/src/db/models.py
+++ b/apps/mw/src/db/models.py
@@ -100,6 +100,7 @@ class CallRecordStatus(str, Enum):
     COMPLETED = "completed"
     SKIPPED = "skipped"
     ERROR = "error"
+    MISSING_AUDIO = "missing_audio"
 
 
 JSONBType = JSONB().with_variant(SQLiteJSON(), "sqlite")
@@ -349,7 +350,7 @@ class CallRecord(Base):
             name="chk_call_records_attempts_non_negative",
         ),
         CheckConstraint(
-            "status IN ('pending','downloading','downloaded','transcribing','completed','skipped','error')",
+            "status IN ('pending','downloading','downloaded','transcribing','completed','skipped','error','missing_audio')",
             name="chk_call_records_status",
         ),
         Index(

--- a/apps/mw/src/domain/__init__.py
+++ b/apps/mw/src/domain/__init__.py
@@ -1,2 +1,5 @@
 """Доменные модели и сервисы middleware."""
-# пусто, для доменных модулей
+
+from apps.mw.src.domain.call_recording_downloader import register_http_failure
+
+__all__ = ["register_http_failure"]

--- a/apps/mw/src/domain/call_recording_downloader.py
+++ b/apps/mw/src/domain/call_recording_downloader.py
@@ -1,0 +1,39 @@
+"""Helpers for tracking Bitrix24 call recording download attempts."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from apps.mw.src.db.models import CallRecord, CallRecordStatus
+
+MISSING_AUDIO_HTTP_STATUS = {403, 404}
+DEFAULT_MAX_ATTEMPTS = 5
+
+
+def _now_utc() -> datetime:
+    """Return timezone-aware timestamp for bookkeeping fields."""
+
+    return datetime.now(timezone.utc)
+
+
+def register_http_failure(
+    record: CallRecord,
+    *,
+    status_code: int,
+    message: str | None = None,
+    max_attempts: int = DEFAULT_MAX_ATTEMPTS,
+) -> None:
+    """Persist the outcome of a failed download attempt on the ORM entity."""
+
+    record.attempts += 1
+    record.last_attempt_at = _now_utc()
+    record.error_code = f"http_{status_code}"
+    record.error_message = message or f"HTTP {status_code}"
+
+    if status_code in MISSING_AUDIO_HTTP_STATUS and record.attempts >= max_attempts:
+        record.status = CallRecordStatus.MISSING_AUDIO
+    else:
+        record.status = CallRecordStatus.ERROR
+
+
+__all__ = ["register_http_failure", "DEFAULT_MAX_ATTEMPTS", "MISSING_AUDIO_HTTP_STATUS"]

--- a/tests/test_call_recording_downloader.py
+++ b/tests/test_call_recording_downloader.py
@@ -1,0 +1,60 @@
+"""Unit tests for the Bitrix24 call recording download helpers."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import uuid4
+
+import pytest
+
+from apps.mw.src.db.models import CallRecord, CallRecordStatus
+from apps.mw.src.domain import register_http_failure
+
+
+def _make_record(*, attempts: int, status: CallRecordStatus = CallRecordStatus.DOWNLOADING) -> CallRecord:
+    return CallRecord(
+        run_id=uuid4(),
+        call_id="CALL-001",
+        duration_sec=120,
+        status=status,
+        recording_url="https://example.com/audio.wav",
+        attempts=attempts,
+    )
+
+
+def test_register_http_failure_marks_missing_audio_after_limit(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When attempts hit the ceiling on 404 the record is marked as missing audio."""
+
+    record = _make_record(attempts=4)
+    frozen_now = datetime(2024, 10, 1, 12, 0, 0)
+    monkeypatch.setattr(
+        "apps.mw.src.domain.call_recording_downloader._now_utc",
+        lambda: frozen_now,
+    )
+
+    register_http_failure(record, status_code=404, message="Recording not found", max_attempts=5)
+
+    assert record.status is CallRecordStatus.MISSING_AUDIO
+    assert record.attempts == 5
+    assert record.error_code == "http_404"
+    assert record.error_message == "Recording not found"
+    assert record.last_attempt_at == frozen_now
+
+
+def test_register_http_failure_keeps_error_before_limit(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Before the limit 403 responses keep the record in ``error`` for retry."""
+
+    record = _make_record(attempts=1)
+    frozen_now = datetime(2024, 10, 1, 13, 0, 0)
+    monkeypatch.setattr(
+        "apps.mw.src.domain.call_recording_downloader._now_utc",
+        lambda: frozen_now,
+    )
+
+    register_http_failure(record, status_code=403, message="Forbidden", max_attempts=5)
+
+    assert record.status is CallRecordStatus.ERROR
+    assert record.attempts == 2
+    assert record.error_code == "http_403"
+    assert record.error_message == "Forbidden"
+    assert record.last_attempt_at == frozen_now

--- a/tests/test_db_models_call_exports.py
+++ b/tests/test_db_models_call_exports.py
@@ -163,6 +163,20 @@ def test_call_record_crud_and_cascade() -> None:
         assert updated.cost_amount == Decimal("12.34")
         assert updated.cost_currency == "RUB"
 
+        updated.status = CallRecordStatus.MISSING_AUDIO
+        updated.error_code = "http_404"
+        updated.error_message = "Recording was not found"
+        updated.attempts = 5
+        session.commit()
+        session.expunge_all()
+
+        missing = session.get(CallRecord, record_id)
+        assert missing is not None
+        assert missing.status is CallRecordStatus.MISSING_AUDIO
+        assert missing.error_code == "http_404"
+        assert missing.error_message == "Recording was not found"
+        assert missing.attempts == 5
+
         duplicate = CallRecord(
             run_id=run_id,
             call_id="CALL-001",


### PR DESCRIPTION
## Summary
- extend the call record enum and database constraints to allow the new `missing_audio` state
- add an Alembic follow-up migration plus domain helper to register HTTP download failures
- expand ORM regression tests and add unit coverage for the missing-audio retry logic

## Testing
- PYTHONPATH=/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages:/workspace/mastermobile pytest /workspace/mastermobile/tests


------
https://chatgpt.com/codex/tasks/task_e_68d7d39ad3c4832a8d3e31b1a7ca5050