### PR TITLE
feat: add structured logging pipeline

### DIFF
--- a/apps/mw/src/observability/__init__.py
+++ b/apps/mw/src/observability/__init__.py
@@ -1,0 +1,17 @@
+"""Observability helpers (logging, tracing, metrics)."""
+
+from .logging import (
+    RequestContextMiddleware,
+    configure_logging,
+    correlation_context,
+    create_logging_lifespan,
+    get_correlation_id,
+)
+
+__all__ = [
+    "RequestContextMiddleware",
+    "configure_logging",
+    "correlation_context",
+    "create_logging_lifespan",
+    "get_correlation_id",
+]

--- a/apps/mw/src/observability/logging.py
+++ b/apps/mw/src/observability/logging.py
@@ -1,0 +1,137 @@
+"""Logging configuration and request correlation helpers."""
+from __future__ import annotations
+
+import sys
+from contextlib import asynccontextmanager, contextmanager
+from contextvars import ContextVar, Token
+from typing import Any, AsyncIterator, Callable, Iterator
+
+from fastapi import FastAPI
+from loguru import logger
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+
+from apps.mw.src.api.dependencies import provide_request_id
+from apps.mw.src.config import Settings, get_settings
+
+_correlation_id_var: ContextVar[str | None] = ContextVar("correlation_id", default=None)
+
+_SENSITIVE_EXACT = {"from", "to"}
+_SENSITIVE_SUBSTRINGS = (
+    "phone",
+    "email",
+    "token",
+    "secret",
+    "password",
+    "authorization",
+    "cookie",
+)
+_MASKED_VALUE = "[REDACTED]"
+
+
+def get_correlation_id() -> str | None:
+    """Return the current correlation identifier from the context."""
+
+    return _correlation_id_var.get()
+
+
+@contextmanager
+def correlation_context(correlation_id: str) -> Iterator[None]:
+    """Temporarily bind the provided correlation id to the logging context."""
+
+    token = _correlation_id_var.set(correlation_id)
+    try:
+        yield
+    finally:
+        _correlation_id_var.reset(token)
+
+
+def _is_sensitive_key(key: str | None) -> bool:
+    if key is None:
+        return False
+    normalized = key.lower()
+    if normalized in _SENSITIVE_EXACT:
+        return True
+    return any(part in normalized for part in _SENSITIVE_SUBSTRINGS)
+
+
+def _mask_value(key: str | None, value: Any) -> Any:
+    if isinstance(value, dict):
+        return {inner_key: _mask_value(inner_key, inner_value) for inner_key, inner_value in value.items()}
+    if isinstance(value, list):
+        return [_mask_value(key, item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_mask_value(key, item) for item in value)
+    if _is_sensitive_key(key):
+        return _MASKED_VALUE
+    return value
+
+
+def _mask_extra(extra: dict[str, Any]) -> dict[str, Any]:
+    return {key: _mask_value(key, value) for key, value in extra.items()}
+
+
+def _build_patcher(settings: Settings):
+    def _patch(record: dict[str, Any]) -> None:
+        correlation_id = _correlation_id_var.get()
+        record.setdefault("extra", {})
+        record["extra"]["correlation_id"] = correlation_id
+
+        if settings.pii_masking_enabled:
+            record["extra"] = _mask_extra(record["extra"])
+
+    return _patch
+
+
+def configure_logging(*, sink: Any | None = None) -> None:
+    """Configure loguru to emit JSON logs with optional PII masking."""
+
+    settings = get_settings()
+    handler_sink = sink if sink is not None else sys.stdout
+
+    logger.remove()
+    logger.configure(
+        handlers=[
+            {
+                "sink": handler_sink,
+                "level": settings.log_level.upper(),
+                "serialize": True,
+                "backtrace": False,
+                "diagnose": False,
+            }
+        ],
+        extra={"correlation_id": None},
+        patcher=_build_patcher(settings),
+    )
+
+
+def create_logging_lifespan(*, sink: Any | None = None) -> Callable[[FastAPI], AsyncIterator[None]]:
+    """Return a FastAPI lifespan context manager that initialises logging."""
+
+    @asynccontextmanager
+    async def _lifespan(_: FastAPI) -> AsyncIterator[None]:
+        configure_logging(sink=sink)
+        yield
+
+    return _lifespan
+
+
+class RequestContextMiddleware(BaseHTTPMiddleware):
+    """Attach a correlation id to each request and logging context."""
+
+    async def dispatch(self, request: Request, call_next) -> Response:  # type: ignore[override]
+        provisional_response = Response()
+        request_id = provide_request_id(provisional_response, request.headers.get("X-Request-Id"))
+        request.state.request_id = request_id
+        token: Token[str | None] = _correlation_id_var.set(request_id)
+
+        try:
+            response = await call_next(request)
+        except Exception:
+            raise
+        else:
+            provide_request_id(response, request_id)
+            return response
+        finally:
+            _correlation_id_var.reset(token)

--- a/tests/test_observability_logging.py
+++ b/tests/test_observability_logging.py
@@ -1,0 +1,91 @@
+"""Tests for logging correlation id injection and PII masking."""
+from __future__ import annotations
+
+import asyncio
+import io
+import json
+
+from loguru import logger
+from starlette.requests import Request
+from starlette.responses import Response
+
+from apps.mw.src.config.settings import get_settings
+from apps.mw.src.observability.logging import (
+    RequestContextMiddleware,
+    configure_logging,
+)
+
+
+def _parse_logs(buffer: io.StringIO) -> list[dict[str, object]]:
+    buffer.seek(0)
+    lines = [line for line in buffer.getvalue().splitlines() if line.strip()]
+    return [json.loads(line)["record"] for line in lines]
+
+
+def test_pii_masking_masks_sensitive_fields_when_enabled(monkeypatch) -> None:
+    """PII masking replaces sensitive fields with a redacted marker."""
+
+    monkeypatch.setenv("PII_MASKING_ENABLED", "true")
+    get_settings.cache_clear()
+
+    buffer = io.StringIO()
+    configure_logging(sink=buffer)
+
+    logger.bind(
+        event="call_export.download",
+        stage="test",
+        call_id="call-123",
+        phone_number="+79001234567",
+        email="agent@example.com",
+    ).info("PII masking test")
+
+    records = _parse_logs(buffer)
+    assert records, "Expected at least one log entry"
+    extra = records[-1]["extra"]
+    assert extra["phone_number"] == "[REDACTED]"
+    assert extra["email"] == "[REDACTED]"
+
+
+async def test_request_context_injects_request_id_into_logs(monkeypatch) -> None:
+    """Request middleware injects correlation id for main and background tasks."""
+
+    monkeypatch.delenv("PII_MASKING_ENABLED", raising=False)
+    get_settings.cache_clear()
+
+    buffer = io.StringIO()
+    configure_logging(sink=buffer)
+
+    middleware = RequestContextMiddleware(lambda scope, receive, send: None)
+
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/log",
+        "headers": [(b"x-request-id", b"req-789")],
+        "query_string": b"",
+        "client": ("test", 0),
+        "server": ("test", 80),
+        "scheme": "http",
+    }
+
+    async def receive() -> dict[str, object]:
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    request = Request(scope, receive)
+
+    async def call_next(_: Request) -> Response:
+        logger.bind(event="test", stage="main", call_id="call-456").info("main request log")
+
+        async def background() -> None:
+            logger.bind(event="test", stage="background", call_id="call-456").info("background log")
+
+        await asyncio.create_task(background())
+        return Response(status_code=200)
+
+    response = await middleware.dispatch(request, call_next)
+    assert response.status_code == 200
+    assert response.headers.get("X-Request-Id") == "req-789"
+
+    records = _parse_logs(buffer)
+    assert len(records) >= 2
+    assert {entry["extra"]["correlation_id"] for entry in records} == {"req-789"}


### PR DESCRIPTION
## Summary
- configure loguru to emit JSON logs with optional PII masking and request correlation via FastAPI lifespan middleware
- update call export integrations and worker paths to emit structured event logs with retry metadata
- add tests covering PII masking redaction and correlation id propagation

## Testing
- PYTHONPATH=. pytest tests/test_observability_logging.py
- PYTHONPATH=. pytest *(fails: missing optional dependency boto3)*


------
https://chatgpt.com/codex/tasks/task_e_68d7d725c3a8832aa0305b264afa4960