### PR TITLE
fix: rename call registry export filename

### DIFF
--- a/apps/mw/src/api/routes/call_registry.py
+++ b/apps/mw/src/api/routes/call_registry.py
@@ -116,7 +116,7 @@ def export_call_registry(
     rows = session.scalars(stmt).all()
 
     filename = (
-        f"call_registry_{period_from.strftime('%Y%m%dT%H%M%S')}"
+        f"registry/calls_{period_from.strftime('%Y%m%dT%H%M%S')}"
         f"_{period_to.strftime('%Y%m%dT%H%M%S')}.csv"
     )
 

--- a/tests/test_call_registry_api.py
+++ b/tests/test_call_registry_api.py
@@ -127,7 +127,12 @@ async def test_export_call_registry_streams_csv(
     assert response.status_code == 200
     assert response.headers["Content-Type"].startswith("text/csv")
     assert response.headers["X-Request-Id"] == "req-call-registry-1"
-    assert response.headers["Content-Disposition"].endswith('.csv"')
+    expected_filename = (
+        "registry/calls_20240101T000000_20240101T235959.csv"
+    )
+    assert response.headers["Content-Disposition"] == (
+        f'attachment; filename="{expected_filename}"'
+    )
 
     content = response.content
     assert content.startswith(codecs.BOM_UTF8)


### PR DESCRIPTION
## Summary
- update the call registry export attachment name to follow the registry/calls_<from>_<to>.csv convention
- extend the API test to assert the new filename so regressions are caught

## Testing
- PYTHONPATH=. pytest tests/test_call_registry_api.py *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*


------
https://chatgpt.com/codex/tasks/task_e_68d7d9fa88b4832a8783ce2d5cd9d2d0