### PR TITLE
feat(stt): add redis transcription worker service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: init up down logs lint typecheck test fmt openapi db-upgrade db-downgrade run seed
+.PHONY: init up down logs lint typecheck test fmt openapi db-upgrade db-downgrade run seed worker
 
 VENV_DIR := .venv
 VENV_BIN := $(VENV_DIR)/bin
@@ -52,3 +52,6 @@ run:
 
 seed:
 	@echo "TODO: seed script"
+
+worker:
+	docker compose up stt-worker

--- a/README.md
+++ b/README.md
@@ -13,10 +13,12 @@
 ## Быстрый старт (локально)
 1. `make init`
 2. `make up`
-3. `make seed` — по мере появления данных
-4. `make test`
+3. `make worker` — запускает отдельный STT-воркер (в отдельном терминале)
+4. `make seed` — по мере появления данных
+5. `make test`
 
 > Для запуска только зависимостей можно выполнить `docker compose up -d db redis`.
+> Метрики Prometheus доступны по адресу `http://localhost:8000/metrics`.
 
 ## Переменные окружения Compose
 

--- a/apps/mw/src/app.py
+++ b/apps/mw/src/app.py
@@ -18,10 +18,15 @@ from apps.mw.src.api.routes import returns as returns_router
 from apps.mw.src.api.routes import system as system_router
 from apps.mw.src.api.schemas import Error, Health
 from apps.mw.src.health import get_health_payload
-from apps.mw.src.observability import RequestContextMiddleware, create_logging_lifespan
+from apps.mw.src.observability import (
+    RequestContextMiddleware,
+    create_logging_lifespan,
+    register_metrics,
+)
 
 app = FastAPI(title="MasterMobile MW", lifespan=create_logging_lifespan())
 app.add_middleware(RequestContextMiddleware)
+register_metrics(app)
 
 app.include_router(system_router.router)
 app.include_router(call_registry_router.router)

--- a/apps/mw/src/observability/__init__.py
+++ b/apps/mw/src/observability/__init__.py
@@ -7,6 +7,7 @@ from .logging import (
     create_logging_lifespan,
     get_correlation_id,
 )
+from .metrics import STT_JOB_DURATION_SECONDS, STT_JOBS_TOTAL, register_metrics
 
 __all__ = [
     "RequestContextMiddleware",
@@ -14,4 +15,7 @@ __all__ = [
     "correlation_context",
     "create_logging_lifespan",
     "get_correlation_id",
+    "STT_JOB_DURATION_SECONDS",
+    "STT_JOBS_TOTAL",
+    "register_metrics",
 ]

--- a/apps/mw/src/observability/metrics.py
+++ b/apps/mw/src/observability/metrics.py
@@ -1,0 +1,32 @@
+"""Prometheus metrics helpers for the middleware services."""
+from __future__ import annotations
+
+from typing import Final
+
+from fastapi import FastAPI, Response
+from prometheus_client import CONTENT_TYPE_LATEST, Counter, Histogram, generate_latest
+
+STT_JOBS_TOTAL: Final[Counter] = Counter(
+    "stt_jobs_total",
+    "Total number of STT jobs handled by the worker, labelled by final status.",
+    labelnames=("status",),
+)
+"""Global counter that tracks STT job outcomes."""
+
+STT_JOB_DURATION_SECONDS: Final[Histogram] = Histogram(
+    "stt_job_duration_seconds",
+    "Histogram of end-to-end STT job processing time in seconds.",
+)
+"""Histogram that records how long a job spent in the worker pipeline."""
+
+
+def register_metrics(app: FastAPI) -> None:
+    """Attach the Prometheus `/metrics` endpoint to the FastAPI application."""
+
+    @app.get("/metrics")
+    async def metrics_endpoint() -> Response:  # pragma: no cover - exercised in integration
+        payload = generate_latest()
+        return Response(content=payload, media_type=CONTENT_TYPE_LATEST)
+
+
+__all__ = ["STT_JOBS_TOTAL", "STT_JOB_DURATION_SECONDS", "register_metrics"]

--- a/apps/mw/src/services/stt_queue.py
+++ b/apps/mw/src/services/stt_queue.py
@@ -1,0 +1,261 @@
+"""Redis-backed queue helpers for Speech-to-Text jobs."""
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any, Final, cast
+
+from loguru import logger
+from redis import Redis
+from sqlalchemy.orm import Session
+
+from apps.mw.src.config import Settings, get_settings
+from apps.mw.src.db.models import CallRecord, CallRecordStatus
+
+STT_QUEUE_KEY: Final[str] = "stt:jobs"
+STT_DLQ_KEY: Final[str] = "stt:jobs:dlq"
+STT_PROCESSED_KEY: Final[str] = "stt:jobs:processed"
+
+
+@dataclass(slots=True)
+class STTJob:
+    """Envelope for a single transcription job."""
+
+    record_id: int
+    call_id: str
+    recording_url: str
+    engine: str
+    language: str | None = None
+
+    @property
+    def dedup_key(self) -> str:
+        """Return a stable idempotency key for the job."""
+
+        return f"{self.call_id}|{self.recording_url}|{self.engine}"
+
+    def to_payload(self) -> dict[str, Any]:
+        """Return a JSON-serialisable payload."""
+
+        return {
+            "record_id": self.record_id,
+            "call_id": self.call_id,
+            "recording_url": self.recording_url,
+            "engine": self.engine,
+            "language": self.language,
+        }
+
+    @classmethod
+    def from_mapping(cls, payload: Mapping[str, Any]) -> STTJob:
+        """Create a job from a mapping payload."""
+
+        try:
+            record_id = int(payload["record_id"])
+            call_id = str(payload["call_id"])
+            recording_url = str(payload["recording_url"])
+            engine = str(payload["engine"])
+        except KeyError as exc:  # pragma: no cover - defensive
+            raise ValueError("payload is missing required fields") from exc
+
+        language = payload.get("language")
+        if language is not None:
+            language = str(language)
+
+        return cls(
+            record_id=record_id,
+            call_id=call_id,
+            recording_url=recording_url,
+            engine=engine,
+            language=language,
+        )
+
+    @classmethod
+    def from_json(cls, payload: str) -> STTJob:
+        """Create a job from a JSON string."""
+
+        data = json.loads(payload)
+        if not isinstance(data, Mapping):  # pragma: no cover - defensive
+            raise ValueError("payload must be a JSON object")
+        return cls.from_mapping(data)
+
+
+@dataclass(slots=True)
+class DLQEntry:
+    """Structured representation of a failed job."""
+
+    job: STTJob
+    reason: str
+    status_code: int | None = None
+    failed_at: datetime = field(default_factory=lambda: datetime.now(tz=UTC))
+
+    def to_payload(self) -> dict[str, Any]:
+        """Return a JSON payload describing the failure."""
+
+        payload: dict[str, Any] = {
+            "job": self.job.to_payload(),
+            "reason": self.reason,
+            "failed_at": self.failed_at.isoformat(),
+        }
+        if self.status_code is not None:
+            payload["status_code"] = self.status_code
+        return payload
+
+
+def create_redis_client(settings: Settings | None = None) -> Redis:
+    """Create a Redis client configured from application settings."""
+
+    settings = settings or get_settings()
+    return Redis(
+        host=settings.redis_host,
+        port=settings.redis_port,
+        decode_responses=True,
+    )
+
+
+class STTQueue:
+    """Redis-backed queue with idempotency and DLQ helpers."""
+
+    def __init__(
+        self,
+        redis_client: Redis,
+        *,
+        queue_key: str = STT_QUEUE_KEY,
+        dlq_key: str = STT_DLQ_KEY,
+        processed_key: str = STT_PROCESSED_KEY,
+    ) -> None:
+        self._redis = redis_client
+        self._queue_key = queue_key
+        self._dlq_key = dlq_key
+        self._processed_key = processed_key
+
+    def enqueue(self, job: STTJob) -> None:
+        """Append a job to the main queue respecting idempotency."""
+
+        if self.is_processed(job):
+            logger.bind(call_id=job.call_id, engine=job.engine).info(
+                "Skipping enqueue for already processed STT job",
+            )
+            return
+
+        self._redis.rpush(self._queue_key, json.dumps(job.to_payload()))
+
+    def fetch_job(self, *, timeout: int | None = None) -> STTJob | None:
+        """Pop the next job from the queue, skipping duplicates."""
+
+        block = timeout is not None and timeout > 0
+        wait_timeout = timeout or 0
+
+        while True:
+            item: str | None
+            if block:
+                result = self._redis.blpop([self._queue_key], timeout=wait_timeout)
+                block = False
+                wait_timeout = 0
+                if result is None:
+                    return None
+                item = cast(str, result[1])
+            else:
+                item = self._redis.lpop(self._queue_key)
+                if item is None:
+                    return None
+
+            job = STTJob.from_json(item)
+            if self.is_processed(job):
+                logger.bind(call_id=job.call_id, engine=job.engine).warning(
+                    "Skipping duplicate STT job",
+                )
+                continue
+            return job
+
+    def is_processed(self, job: STTJob) -> bool:
+        """Return whether the job's idempotency key has been processed."""
+
+        return bool(self._redis.sismember(self._processed_key, job.dedup_key))
+
+    def mark_processed(self, job: STTJob) -> None:
+        """Persist the job idempotency key."""
+
+        self._redis.sadd(self._processed_key, job.dedup_key)
+
+    def push_to_dlq(self, entry: DLQEntry) -> None:
+        """Append a failure entry to the dedicated DLQ."""
+
+        self._redis.rpush(self._dlq_key, json.dumps(entry.to_payload()))
+
+    def mark_transcribing(self, session: Session, job: STTJob) -> CallRecord | None:
+        """Set the CallRecord to transcribing and bump attempt counters."""
+
+        record = session.get(CallRecord, job.record_id)
+        if record is None:
+            logger.bind(call_id=job.call_id, record_id=job.record_id).warning(
+                "CallRecord for STT job not found",
+            )
+            return None
+
+        record.status = CallRecordStatus.TRANSCRIBING
+        record.attempts += 1
+        record.last_attempt_at = datetime.now(tz=UTC)
+        session.commit()
+        return record
+
+    def record_success(
+        self,
+        session: Session,
+        job: STTJob,
+        *,
+        transcript_path: str,
+        transcript_lang: str | None,
+    ) -> None:
+        """Persist successful transcription details on the CallRecord."""
+
+        record = session.get(CallRecord, job.record_id)
+        if record is None:
+            logger.bind(call_id=job.call_id, record_id=job.record_id).error(
+                "CallRecord missing when storing transcript",
+            )
+            return
+
+        record.transcript_path = transcript_path
+        record.transcript_lang = transcript_lang
+        record.status = CallRecordStatus.COMPLETED
+        record.error_code = None
+        record.error_message = None
+        record.last_attempt_at = datetime.now(tz=UTC)
+        session.commit()
+        self.mark_processed(job)
+
+    def record_failure(
+        self,
+        session: Session,
+        job: STTJob,
+        *,
+        error_code: str,
+        error_message: str,
+    ) -> None:
+        """Persist failure metadata on the CallRecord."""
+
+        record = session.get(CallRecord, job.record_id)
+        if record is None:
+            logger.bind(call_id=job.call_id, record_id=job.record_id).error(
+                "CallRecord missing when recording STT error",
+            )
+            return
+
+        record.status = CallRecordStatus.ERROR
+        record.error_code = error_code
+        record.error_message = error_message
+        record.last_attempt_at = datetime.now(tz=UTC)
+        session.commit()
+        self.mark_processed(job)
+
+
+__all__ = [
+    "DLQEntry",
+    "STTJob",
+    "STTQueue",
+    "create_redis_client",
+    "STT_QUEUE_KEY",
+    "STT_DLQ_KEY",
+    "STT_PROCESSED_KEY",
+]

--- a/apps/mw/src/services/stt_worker.py
+++ b/apps/mw/src/services/stt_worker.py
@@ -1,0 +1,247 @@
+"""Background worker that processes STT jobs from Redis."""
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from time import perf_counter, sleep
+from typing import Protocol
+
+from loguru import logger
+from sqlalchemy.orm import Session
+
+from apps.mw.src.config import get_settings
+from apps.mw.src.db.session import SessionLocal
+from apps.mw.src.observability import STT_JOB_DURATION_SECONDS, STT_JOBS_TOTAL
+from apps.mw.src.services.stt_queue import DLQEntry, STTJob, STTQueue, create_redis_client
+
+DEFAULT_MAX_RETRIES = 5
+DEFAULT_BACKOFF_SECONDS = 2.0
+
+
+@dataclass(slots=True)
+class TranscriptionResult:
+    """Successful transcription metadata."""
+
+    transcript_path: str
+    language: str | None = None
+
+
+class SpeechToTextProvider(Protocol):
+    """Simple protocol for transcription providers."""
+
+    def transcribe(self, job: STTJob) -> TranscriptionResult:  # pragma: no cover - Protocol
+        ...
+
+
+class TranscriptionError(Exception):
+    """Raised by providers when a transcription attempt failed."""
+
+    def __init__(self, status_code: int | None, message: str) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+
+class PlaceholderTranscriber:
+    """A minimal local transcriber used until a real backend is wired in."""
+
+    def __init__(self, transcripts_dir: Path) -> None:
+        self._transcripts_dir = transcripts_dir
+
+    def transcribe(self, job: STTJob) -> TranscriptionResult:
+        self._transcripts_dir.mkdir(parents=True, exist_ok=True)
+        target = self._transcripts_dir / f"{job.call_id}.txt"
+        if not target.exists():
+            target.write_text(
+                "Transcription placeholder. Configure a real STT provider to replace this output.\n",
+                encoding="utf-8",
+            )
+        return TranscriptionResult(transcript_path=str(target), language=job.language)
+
+
+class STTWorker:
+    """Long-running worker that processes STT jobs with retry semantics."""
+
+    def __init__(
+        self,
+        queue: STTQueue,
+        transcriber: SpeechToTextProvider,
+        *,
+        session_factory: Callable[[], Session] = SessionLocal,
+        max_retries: int = DEFAULT_MAX_RETRIES,
+        base_backoff_seconds: float = DEFAULT_BACKOFF_SECONDS,
+        idle_sleep_seconds: float = 1.0,
+    ) -> None:
+        self._queue = queue
+        self._transcriber = transcriber
+        self._session_factory = session_factory
+        self._max_retries = max(1, max_retries)
+        self._base_backoff = max(0.1, base_backoff_seconds)
+        self._idle_sleep = max(0.1, idle_sleep_seconds)
+
+    def run_forever(self, *, timeout: int = 5) -> None:
+        """Blocking loop that keeps polling the queue for new jobs."""
+
+        logger.info("Starting STT worker loop")
+        while True:  # pragma: no cover - integration loop
+            handled = self.process_next(timeout=timeout)
+            if not handled:
+                sleep(self._idle_sleep)
+
+    def process_next(self, *, timeout: int | None = None) -> bool:
+        """Process a single job from the queue."""
+
+        job = self._queue.fetch_job(timeout=timeout)
+        if job is None:
+            return False
+
+        logger.bind(call_id=job.call_id, engine=job.engine).info("Processing STT job")
+        start = perf_counter()
+        session = self._session_factory()
+        try:
+            record = self._queue.mark_transcribing(session, job)
+            if record is None:
+                STT_JOBS_TOTAL.labels(status="missing_record").inc()
+                self._queue.mark_processed(job)
+                return True
+
+            result = self._transcribe_with_retry(session, job)
+            if result is None:
+                return True
+
+            self._queue.record_success(
+                session,
+                job,
+                transcript_path=result.transcript_path,
+                transcript_lang=result.language,
+            )
+            STT_JOBS_TOTAL.labels(status="success").inc()
+            logger.bind(call_id=job.call_id, engine=job.engine).info(
+                "STT job completed",
+            )
+            return True
+        finally:
+            session.close()
+            STT_JOB_DURATION_SECONDS.observe(perf_counter() - start)
+
+    def _transcribe_with_retry(self, session: Session, job: STTJob) -> TranscriptionResult | None:
+        """Execute the transcription with exponential backoff for retryable errors."""
+
+        attempt = 0
+        while True:
+            try:
+                return self._transcriber.transcribe(job)
+            except TranscriptionError as exc:
+                attempt += 1
+                status_code = exc.status_code
+                message = str(exc)
+                if status_code is not None and 400 <= status_code < 500:
+                    self._handle_client_failure(session, job, status_code, message)
+                    return None
+
+                if attempt >= self._max_retries:
+                    self._handle_exhausted_retries(session, job, status_code, message)
+                    return None
+
+                delay = self._base_backoff * (2 ** (attempt - 1))
+                STT_JOBS_TOTAL.labels(status="retry").inc()
+                logger.bind(
+                    call_id=job.call_id,
+                    engine=job.engine,
+                    attempt=attempt,
+                    status_code=status_code,
+                    delay=delay,
+                ).warning("Retrying STT job after server error")
+                sleep(delay)
+            except Exception as exc:  # pragma: no cover - defensive guard
+                attempt += 1
+                if attempt >= self._max_retries:
+                    reason = str(exc)
+                    self._queue.record_failure(
+                        session,
+                        job,
+                        error_code="unexpected_error",
+                        error_message=reason,
+                    )
+                    self._queue.push_to_dlq(DLQEntry(job=job, reason=reason))
+                    STT_JOBS_TOTAL.labels(status="dlq").inc()
+                    logger.bind(call_id=job.call_id, engine=job.engine).exception(
+                        "Unexpected STT worker failure",
+                    )
+                    return None
+
+                delay = self._base_backoff * (2 ** (attempt - 1))
+                STT_JOBS_TOTAL.labels(status="retry").inc()
+                logger.bind(
+                    call_id=job.call_id,
+                    engine=job.engine,
+                    attempt=attempt,
+                    delay=delay,
+                ).exception("Retrying after unexpected STT worker error")
+                sleep(delay)
+
+    def _handle_client_failure(
+        self,
+        session: Session,
+        job: STTJob,
+        status_code: int,
+        message: str,
+    ) -> None:
+        """Record a non-retryable HTTP error and push to the DLQ."""
+
+        reason = f"{status_code}: {message}"
+        self._queue.record_failure(
+            session,
+            job,
+            error_code=f"http_{status_code}",
+            error_message=message,
+        )
+        self._queue.push_to_dlq(
+            DLQEntry(job=job, reason=reason, status_code=status_code),
+        )
+        STT_JOBS_TOTAL.labels(status="dlq").inc()
+        logger.bind(call_id=job.call_id, engine=job.engine, status_code=status_code).error(
+            "STT job moved to DLQ after client error",
+        )
+
+    def _handle_exhausted_retries(
+        self,
+        session: Session,
+        job: STTJob,
+        status_code: int | None,
+        message: str,
+    ) -> None:
+        """Persist a failure when retries are exhausted."""
+
+        error_code = "max_retries"
+        reason = message if status_code is None else f"{status_code}: {message}"
+        self._queue.record_failure(
+            session,
+            job,
+            error_code=error_code,
+            error_message=reason,
+        )
+        self._queue.push_to_dlq(
+            DLQEntry(job=job, reason=reason, status_code=status_code),
+        )
+        STT_JOBS_TOTAL.labels(status="dlq").inc()
+        logger.bind(call_id=job.call_id, engine=job.engine, status_code=status_code).error(
+            "STT job moved to DLQ after exhausting retries",
+        )
+
+
+def main() -> None:  # pragma: no cover - CLI entry point
+    """Run the worker using the default Redis connection."""
+
+    settings = get_settings()
+    redis_client = create_redis_client(settings)
+    queue = STTQueue(redis_client)
+    transcripts_dir = Path(settings.local_storage_dir) / "transcripts"
+    transcriber = PlaceholderTranscriber(transcripts_dir)
+
+    worker = STTWorker(queue, transcriber)
+    worker.run_forever()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,44 @@ services:
       retries: 5
       start_period: 10s
 
+  stt-worker:
+    build:
+      context: .
+      dockerfile: apps/mw/Dockerfile
+    image: mastermobile-app:local
+    command: >-
+      python -m apps.mw.src.services.stt_worker
+    env_file:
+      - .env.example
+      - .env
+    environment:
+      B24_BASE_URL: ${B24_BASE_URL:-https://example.bitrix24.ru/rest}
+      B24_WEBHOOK_USER_ID: ${B24_WEBHOOK_USER_ID:-1}
+      B24_WEBHOOK_TOKEN: ${B24_WEBHOOK_TOKEN:-changeme}
+      B24_RATE_LIMIT_RPS: ${B24_RATE_LIMIT_RPS:-2.0}
+      B24_BACKOFF_SECONDS: ${B24_BACKOFF_SECONDS:-5}
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      OPENAI_BASE_URL: ${OPENAI_BASE_URL:-https://api.openai.com/v1}
+      WHISPER_RATE_PER_MIN_USD: ${WHISPER_RATE_PER_MIN_USD:-0.006}
+      STT_MAX_FILE_MINUTES: ${STT_MAX_FILE_MINUTES:-0}
+      CHATGPT_PROXY_URL: ${CHATGPT_PROXY_URL:-http://proxy.example.com:8080}
+      STORAGE_BACKEND: ${STORAGE_BACKEND:-local}
+      S3_ENDPOINT_URL: ${S3_ENDPOINT_URL:-}
+      S3_REGION: ${S3_REGION:-}
+      S3_BUCKET: ${S3_BUCKET:-}
+      S3_ACCESS_KEY_ID: ${S3_ACCESS_KEY_ID:-}
+      S3_SECRET_ACCESS_KEY: ${S3_SECRET_ACCESS_KEY:-}
+      LOCAL_STORAGE_DIR: ${LOCAL_STORAGE_DIR:-/app/storage}
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    init: true
+    volumes:
+      - .:/app
+      - ./storage:${LOCAL_STORAGE_DIR:-/app/storage}
+
   db:
     image: postgres:16
     environment:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,8 @@ dependencies = [
     "python-dotenv>=1.0",
     "loguru>=0.7",
     "python-multipart>=0.0.9",
-    "boto3>=1.34"
+    "boto3>=1.34",
+    "prometheus-client>=0.20"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- add a Redis-backed STT queue/worker with idempotency checks, DLQ handling, and placeholder transcription implementation
- expose Prometheus metrics via a new observability module and register the /metrics endpoint for the FastAPI app
- wire the worker into docker-compose/Makefile, document the new command, and add prometheus-client to project dependencies

## Testing
- make lint *(fails: repository has pre-existing ruff violations in migrations, API routes, and tests)*
- make typecheck *(fails: existing mypy issues in legacy modules and third-party stubs)*
- make test *(fails: existing call registry streaming test error unrelated to new queue/worker)*

------
https://chatgpt.com/codex/tasks/task_e_68d7dd8e9eac832ab3a8ee882dfdce84