### PR TITLE
Refine STT smoke fixtures to generate audio on demand

### DIFF
--- a/tests/data/stt_smoke/ATTRIBUTION.md
+++ b/tests/data/stt_smoke/ATTRIBUTION.md
@@ -1,0 +1,5 @@
+# STT Smoke Test Clips
+
+- Synthetic speech is generated on demand by `generate_clips.py`, which wraps the open-source [`gTTS`](https://github.com/pndurette/gTTS) client for Google Text-to-Speech.
+- Spoken phrases are authored specifically for this repository's smoke tests; they contain no personal data.
+- Audio artifacts are not stored in the repository. Review Google's Terms of Service before running the generator or redistributing the resulting files outside this project.

--- a/tests/data/stt_smoke/generate_clips.py
+++ b/tests/data/stt_smoke/generate_clips.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Generate synthetic speech fixtures for STT smoke tests."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+from typing import Iterable
+
+MANIFEST_PATH = Path(__file__).with_name("manifest.json")
+OUTPUT_DIR = MANIFEST_PATH.parent
+
+
+def load_manifest() -> dict:
+    try:
+        with MANIFEST_PATH.open("r", encoding="utf-8") as fp:
+            return json.load(fp)
+    except FileNotFoundError as exc:  # pragma: no cover - defensive guard
+        raise SystemExit(f"Manifest not found: {MANIFEST_PATH}") from exc
+    except json.JSONDecodeError as exc:  # pragma: no cover - defensive guard
+        raise SystemExit(f"Manifest is not valid JSON: {exc}") from exc
+
+
+def iter_clips(selected: Iterable[str] | None = None) -> list[dict]:
+    manifest = load_manifest()
+    clips = manifest.get("clips", [])
+    if selected:
+        index = {clip["filename"]: clip for clip in clips}
+        missing = sorted(set(selected) - set(index))
+        if missing:
+            raise SystemExit(
+                "Unknown clip(s) requested: " + ", ".join(missing)
+            )
+        return [index[name] for name in selected]
+    return clips
+
+
+def ensure_dependencies() -> None:
+    try:
+        import gtts  # noqa: F401
+    except ImportError as exc:  # pragma: no cover - deterministic failure path
+        raise SystemExit(
+            "Missing dependency 'gTTS'. Install with 'pip install gTTS>=2.5.4'."
+        ) from exc
+
+
+def synthesize_clip(clip: dict, force: bool = False) -> Path:
+    ensure_dependencies()
+    from gtts import gTTS  # type: ignore
+
+    target = OUTPUT_DIR / clip["filename"]
+    if target.exists() and not force:
+        print(f"Skipping {target.name} (already exists)")
+        return target
+
+    print(f"Generating {target.name} → {target}")
+    tts = gTTS(text=clip["text"], lang=clip["language"])
+    tts.save(str(target))
+    validate_checksum(target, clip.get("sha256"))
+    return target
+
+
+def validate_checksum(path: Path, expected: str | None) -> None:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(8192), b""):
+            digest.update(chunk)
+    checksum = digest.hexdigest()
+    if expected and checksum != expected:
+        path.unlink(missing_ok=True)
+        raise SystemExit(
+            f"Checksum mismatch for {path.name}: expected {expected}, got {checksum}."
+        )
+    if expected:
+        print(f"Verified checksum for {path.name}: {checksum}")
+    else:
+        print(f"Checksum for {path.name}: {checksum}")
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate speech fixtures defined in manifest.json",
+    )
+    parser.add_argument(
+        "filenames",
+        nargs="*",
+        help="Optional list of filenames to generate. Defaults to all clips.",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite existing files instead of skipping them.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    clips = iter_clips(args.filenames or None)
+    for clip in clips:
+        synthesize_clip(clip, force=args.force)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/data/stt_smoke/manifest.json
+++ b/tests/data/stt_smoke/manifest.json
@@ -1,0 +1,32 @@
+{
+  "generator": {
+    "script": "tests/data/stt_smoke/generate_clips.py",
+    "pip_dependencies": [
+      "gTTS>=2.5.4"
+    ],
+    "notes": "Run the script from the repository root to (re)generate deterministic MP3 fixtures before executing smoke tests."
+  },
+  "clips": [
+    {
+      "filename": "en_hello_world.mp3",
+      "text": "Hello world, this is a smoke test.",
+      "language": "en",
+      "expected_duration_seconds": 2.952,
+      "sha256": "f89cca688532409af27222115673b1705129f48e679e9e1ed78efd812a8d939c"
+    },
+    {
+      "filename": "es_buenos_dias.mp3",
+      "text": "Buenos días, esto es una prueba.",
+      "language": "es",
+      "expected_duration_seconds": 2.952,
+      "sha256": "3d76ea45eb9d474dfbc2ac80d1a9c47be977eb613f674af74ade9ed0586d2162"
+    },
+    {
+      "filename": "fr_bonjour_tout_le_monde.mp3",
+      "text": "Bonjour tout le monde, ceci est un test.",
+      "language": "fr",
+      "expected_duration_seconds": 2.856,
+      "sha256": "4b4ca0d72950cbbbcecc092b19c725a9aeea780177b40bf1716e3fb6881e3359"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- remove committed STT smoke MP3 assets and document generator metadata in the manifest
- add a gTTS-based helper script that recreates the fixtures and verifies recorded checksums
- update the attribution note to explain that audio is produced on demand instead of stored in git

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d7e64328fc832a92758eacd34f76cd