### PR TITLE
fix: ensure call recordings use unique storage keys

### DIFF
--- a/apps/mw/src/services/call_download.py
+++ b/apps/mw/src/services/call_download.py
@@ -66,6 +66,7 @@ async def download_call_record(
             record.call_id,
             stream,
             started_at=record.call_started_at,
+            record_identifier=record.record_id or record.recording_url,
         )
     except httpx.HTTPStatusError as exc:  # pragma: no cover - defensive guard
         _handle_failure(record, f"http_{exc.response.status_code}", str(exc))


### PR DESCRIPTION
## Summary
- allow `StorageService.store_call_recording` to accept a per-record identifier and include it in the generated object key
- propagate the Bitrix24 record identifier through the download workflow so filenames stay unique per recording
- extend the Bitrix24 download tests to cover duplicate call IDs with distinct recordings

## Testing
- `PYTHONPATH=/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages:. pytest tests/test_b24_download.py`


------
https://chatgpt.com/codex/tasks/task_e_68d7ec19d694832aa75fa1109dd9c905