### PR TITLE
feat: enforce unique call recording URLs

### DIFF
--- a/apps/mw/migrations/versions/0006_call_records_unique_recording_url.py
+++ b/apps/mw/migrations/versions/0006_call_records_unique_recording_url.py
@@ -1,0 +1,47 @@
+"""Ensure call_id + recording_url combinations are unique."""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "0006_call_records_unique_recording_url"
+down_revision = "0005_call_records_direction_nullable_cleanup"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        DELETE FROM call_records
+        WHERE id IN (
+            SELECT id FROM (
+                SELECT id,
+                       row_number() OVER (
+                           PARTITION BY call_id, recording_url
+                           ORDER BY id
+                       ) AS row_num
+                FROM call_records
+                WHERE recording_url IS NOT NULL
+            ) duplicates
+            WHERE duplicates.row_num > 1
+        )
+        """
+    )
+
+    op.create_index(
+        "uq_call_records_call_id_recording_url",
+        "call_records",
+        ["call_id", "recording_url"],
+        unique=True,
+        postgresql_where=sa.text("recording_url IS NOT NULL"),
+        sqlite_where=sa.text("recording_url IS NOT NULL"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "uq_call_records_call_id_recording_url",
+        table_name="call_records",
+    )

--- a/apps/mw/src/db/models.py
+++ b/apps/mw/src/db/models.py
@@ -393,6 +393,14 @@ class CallRecord(Base):
             text("coalesce(record_id, '')"),
             unique=True,
         ),
+        Index(
+            "uq_call_records_call_id_recording_url",
+            "call_id",
+            "recording_url",
+            unique=True,
+            postgresql_where=text("recording_url IS NOT NULL"),
+            sqlite_where=text("recording_url IS NOT NULL"),
+        ),
     )
 
     id: Mapped[int] = mapped_column(

--- a/tests/test_call_registry_api.py
+++ b/tests/test_call_registry_api.py
@@ -165,6 +165,60 @@ def _seed_b24_call_records(engine: Engine) -> None:
         session.commit()
 
 
+def test_call_record_duplicate_recording_url_is_rejected(sqlite_engine: Engine) -> None:
+    first_period_from = datetime(2024, 3, 1, 0, 0, 0)
+    first_period_to = first_period_from + timedelta(days=1)
+
+    with Session(sqlite_engine) as session:
+        first_export = CallExport(
+            period_from=first_period_from,
+            period_to=first_period_to,
+            status=CallExportStatus.COMPLETED,
+        )
+        original_record = CallRecord(
+            export=first_export,
+            call_id="CALL-DEDUP",
+            record_id="REC-ORIGINAL",
+            call_started_at=datetime(2024, 3, 1, 9, 0, 0),
+            direction="inbound",
+            from_number="+702000001",
+            to_number="+702000002",
+            duration_sec=120,
+            recording_url="https://example.com/records/dedup.mp3",
+            status=CallRecordStatus.COMPLETED,
+            employee_id="EMP-DEDUP",
+        )
+        session.add_all([first_export, original_record])
+        session.commit()
+
+    second_period_from = datetime(2024, 3, 2, 0, 0, 0)
+    second_period_to = second_period_from + timedelta(days=1)
+
+    with Session(sqlite_engine) as session:
+        second_export = CallExport(
+            period_from=second_period_from,
+            period_to=second_period_to,
+            status=CallExportStatus.COMPLETED,
+        )
+        conflicting_record = CallRecord(
+            export=second_export,
+            call_id="CALL-DEDUP",
+            record_id="REC-SECOND",
+            call_started_at=datetime(2024, 3, 2, 11, 0, 0),
+            direction="outbound",
+            from_number="+702000003",
+            to_number="+702000004",
+            duration_sec=60,
+            recording_url="https://example.com/records/dedup.mp3",
+            status=CallRecordStatus.COMPLETED,
+            employee_id="EMP-DED2",
+        )
+        session.add_all([second_export, conflicting_record])
+
+        with pytest.raises(IntegrityError):
+            session.commit()
+
+
 @pytest.mark.asyncio
 async def test_export_call_registry_streams_csv(
     api_client: httpx.AsyncClient,


### PR DESCRIPTION
## Summary
- add an ORM-level partial unique index on call_id and recording_url so duplicates require a non-null URL
- introduce an Alembic migration that prunes existing duplicates before creating the matching database index
- cover the idempotency requirement with a regression test that asserts duplicate inserts raise IntegrityError

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTHONPATH=. pytest -p pytest_asyncio tests/test_call_registry_api.py::test_call_record_duplicate_recording_url_is_rejected

------
https://chatgpt.com/codex/tasks/task_e_68d7ec1bb52c832a9a242d959bf66986