### PR TITLE
fix(storage): ensure unique filenames for Bitrix24 recordings

### DIFF
--- a/apps/mw/src/services/storage.py
+++ b/apps/mw/src/services/storage.py
@@ -40,10 +40,11 @@ class StorageService:
         stream: AsyncIterable[bytes],
         *,
         started_at: datetime | None,
+        record_identifier: str,
     ) -> StorageResult:
         """Persist the incoming recording stream and return its metadata."""
 
-        key = self._build_object_key(call_id, started_at)
+        key = self._build_object_key(call_id, record_identifier, started_at)
 
         if self._backend == "s3":
             return await self._store_s3(key, stream)
@@ -97,7 +98,12 @@ class StorageService:
             bytes_stored=bytes_written,
         )
 
-    def _build_object_key(self, call_id: str, started_at: datetime | None) -> str:
+    def _build_object_key(
+        self,
+        call_id: str,
+        record_identifier: str,
+        started_at: datetime | None,
+    ) -> str:
         if started_at is not None:
             if started_at.tzinfo is None:
                 started_at = started_at.replace(tzinfo=timezone.utc)
@@ -105,13 +111,28 @@ class StorageService:
         else:
             day = datetime.now(tz=timezone.utc).date()
 
+        suffix = self._sanitize_identifier(record_identifier)
+
         return str(
             Path("raw")
             / f"{day.year:04d}"
             / f"{day.month:02d}"
             / f"{day.day:02d}"
-            / f"call_{call_id}.mp3"
+            / f"call_{call_id}_{suffix}.mp3"
         )
+
+    def _sanitize_identifier(self, identifier: str) -> str:
+        """Normalize identifier so it can be safely used in object keys."""
+
+        sanitized = "".join(
+            char if char.isalnum() or char in {"-", "_"} else "-"
+            for char in identifier
+        ).strip("-_")
+
+        if not sanitized:
+            return hashlib.sha256(identifier.encode("utf-8")).hexdigest()
+
+        return sanitized
 
     def _create_s3_client(self) -> Any:
         return boto3.client(


### PR DESCRIPTION
## Summary
- include a record-specific identifier when generating storage keys so Bitrix24 recordings never overwrite each other
- resolve the identifier from call records (using record_id or a URL digest) before persisting audio streams
- extend download tests to cover duplicate call_id cases and update expectations for the new filenames

## Testing
- PYTHONPATH=. pytest tests/test_b24_download.py *(fails: respx 0.22.0 is incompatible with the installed httpx version and raises AttributeError during plugin loading)*

------
https://chatgpt.com/codex/tasks/task_e_68d7ee573078832ab507ff0c81bbf1be