### PR TITLE
feat: add Prometheus request metrics middleware

### DIFF
--- a/apps/mw/src/app.py
+++ b/apps/mw/src/app.py
@@ -21,12 +21,14 @@ from apps.mw.src.api.schemas import Error, Health
 from apps.mw.src.health import get_health_payload
 from apps.mw.src.observability import (
     RequestContextMiddleware,
+    RequestMetricsMiddleware,
     create_logging_lifespan,
     register_metrics,
 )
 
 app = FastAPI(title="MasterMobile MW", lifespan=create_logging_lifespan())
 app.add_middleware(RequestContextMiddleware)
+app.add_middleware(RequestMetricsMiddleware)
 register_metrics(app)
 
 app.include_router(system_router.router)

--- a/apps/mw/src/observability/__init__.py
+++ b/apps/mw/src/observability/__init__.py
@@ -7,10 +7,20 @@ from .logging import (
     create_logging_lifespan,
     get_correlation_id,
 )
-from .metrics import STT_JOB_DURATION_SECONDS, STT_JOBS_TOTAL, register_metrics
+from .metrics import (
+    HTTP_REQUEST_DURATION_SECONDS,
+    HTTP_REQUESTS_TOTAL,
+    RequestMetricsMiddleware,
+    STT_JOB_DURATION_SECONDS,
+    STT_JOBS_TOTAL,
+    register_metrics,
+)
 
 __all__ = [
+    "HTTP_REQUEST_DURATION_SECONDS",
+    "HTTP_REQUESTS_TOTAL",
     "RequestContextMiddleware",
+    "RequestMetricsMiddleware",
     "configure_logging",
     "correlation_context",
     "create_logging_lifespan",

--- a/apps/mw/src/observability/metrics.py
+++ b/apps/mw/src/observability/metrics.py
@@ -1,10 +1,14 @@
 """Prometheus metrics helpers for the middleware services."""
 from __future__ import annotations
 
+from time import perf_counter
 from typing import Final
 
-from fastapi import FastAPI, Response
+from fastapi import FastAPI, Response, status
 from prometheus_client import CONTENT_TYPE_LATEST, Counter, Histogram, generate_latest
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.requests import Request
+from starlette.responses import Response as StarletteResponse
 
 STT_JOBS_TOTAL: Final[Counter] = Counter(
     "stt_jobs_total",
@@ -19,6 +23,50 @@ STT_JOB_DURATION_SECONDS: Final[Histogram] = Histogram(
 )
 """Histogram that records how long a job spent in the worker pipeline."""
 
+HTTP_REQUESTS_TOTAL: Final[Counter] = Counter(
+    "http_requests_total",
+    "Total number of HTTP requests processed by the middleware service.",
+    labelnames=("method", "status_code", "path"),
+)
+"""Counter that tracks processed HTTP requests broken down by route."""
+
+HTTP_REQUEST_DURATION_SECONDS: Final[Histogram] = Histogram(
+    "http_request_duration_seconds",
+    "Histogram of HTTP request latency in seconds.",
+    labelnames=("method", "status_code", "path"),
+)
+"""Histogram measuring HTTP server latency distribution."""
+
+
+class RequestMetricsMiddleware(BaseHTTPMiddleware):
+    """Collect per-request Prometheus metrics for the FastAPI application."""
+
+    async def dispatch(
+        self,
+        request: Request,
+        call_next: RequestResponseEndpoint,
+    ) -> StarletteResponse:
+        start_time = perf_counter()
+        status_code = None
+        try:
+            response = await call_next(request)
+            status_code = response.status_code
+            return response
+        except Exception:
+            status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
+            raise
+        finally:
+            elapsed = perf_counter() - start_time
+            route = request.scope.get("route")
+            path_template = getattr(route, "path", request.url.path)
+            labels = (
+                request.method,
+                str(status_code or status.HTTP_500_INTERNAL_SERVER_ERROR),
+                path_template,
+            )
+            HTTP_REQUESTS_TOTAL.labels(*labels).inc()
+            HTTP_REQUEST_DURATION_SECONDS.labels(*labels).observe(elapsed)
+
 
 def register_metrics(app: FastAPI) -> None:
     """Attach the Prometheus `/metrics` endpoint to the FastAPI application."""
@@ -29,4 +77,11 @@ def register_metrics(app: FastAPI) -> None:
         return Response(content=payload, media_type=CONTENT_TYPE_LATEST)
 
 
-__all__ = ["STT_JOBS_TOTAL", "STT_JOB_DURATION_SECONDS", "register_metrics"]
+__all__ = [
+    "HTTP_REQUESTS_TOTAL",
+    "HTTP_REQUEST_DURATION_SECONDS",
+    "RequestMetricsMiddleware",
+    "STT_JOBS_TOTAL",
+    "STT_JOB_DURATION_SECONDS",
+    "register_metrics",
+]

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -15,8 +15,8 @@
 ## Метрики
 | Метрика | Тип | Labels | Цель |
 | --- | --- | --- | --- |
-| `http_requests_duration_seconds` | Histogram | `method`, `path_template`, `status_code`, `role` | p95 ≤ 250 мс (чтение), p95 ≤ 400 мс (запись) |
-| `http_requests_total` | Counter | `method`, `path_template`, `status_code`, `role` | Контроль объёма вызовов, rate limit |
+| `http_request_duration_seconds` | Histogram | `method`, `status_code`, `path` | p95 ≤ 250 мс (чтение), p95 ≤ 400 мс (запись) |
+| `http_requests_total` | Counter | `method`, `status_code`, `path` | Контроль объёма вызовов, rate limit |
 | `background_tasks_duration_seconds` | Histogram | `task_name`, `status` | SLA фоновых процессов |
 | `integration_failures_total` | Counter | `system`, `reason`, `retry_stage` | Алерты при росте ошибок внешних систем |
 | `queue_lag_seconds` | Gauge | `queue_name` | Контроль задержек Redis/Kafka (порог 60 сек) |
@@ -24,6 +24,11 @@
 
 - Экспортер: Prometheus `/metrics`, scrape interval 15с.
 - Alertmanager правила: p95 > SLO 5 мин подряд, `integration_failures_total` +50% за 10 мин, `queue_lag_seconds` > 60с.
+
+### Рекомендуемые PromQL запросы
+
+- Ошибка по статусам: ``sum by (status_code)(rate(http_requests_total[5m]))``
+- p95 латентности по маршруту: ``histogram_quantile(0.95, sum by (method, path, le)(rate(http_request_duration_seconds_bucket[5m])))``
 
 ## Трассировки
 - OpenTelemetry SDK. Спаны: `http.server`, `http.client`, `redis.command`, `db.query`, `event.publish`, `event.consume`.

--- a/tests/test_observability_metrics.py
+++ b/tests/test_observability_metrics.py
@@ -1,0 +1,56 @@
+"""Tests for Prometheus request metrics instrumentation."""
+from __future__ import annotations
+
+import httpx
+import pytest
+from fastapi import FastAPI, Response
+
+from apps.mw.src.observability.metrics import (
+    HTTP_REQUESTS_TOTAL,
+    HTTP_REQUEST_DURATION_SECONDS,
+    RequestMetricsMiddleware,
+)
+
+BASE_URL = "http://testserver"
+
+
+@pytest.mark.asyncio
+async def test_request_metrics_increment_for_success_and_error() -> None:
+    """Counter and histogram values increase for 2xx and 5xx responses."""
+
+    app = FastAPI()
+    app.add_middleware(RequestMetricsMiddleware)
+
+    @app.get("/ok")
+    async def ok() -> dict[str, str]:
+        return {"status": "ok"}
+
+    @app.get("/fail")
+    async def fail() -> Response:
+        return Response(status_code=500)
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url=BASE_URL) as client:
+        success_labels = ("GET", "200", "/ok")
+        error_labels = ("GET", "500", "/fail")
+
+        success_counter = HTTP_REQUESTS_TOTAL.labels(*success_labels)
+        error_counter = HTTP_REQUESTS_TOTAL.labels(*error_labels)
+        success_histogram = HTTP_REQUEST_DURATION_SECONDS.labels(*success_labels)
+        error_histogram = HTTP_REQUEST_DURATION_SECONDS.labels(*error_labels)
+
+        success_counter_before = success_counter._value.get()
+        error_counter_before = error_counter._value.get()
+        success_histogram_before = success_histogram._sum.get()
+        error_histogram_before = error_histogram._sum.get()
+
+        ok_response = await client.get("/ok")
+        fail_response = await client.get("/fail")
+
+    assert ok_response.status_code == 200
+    assert fail_response.status_code == 500
+
+    assert success_counter._value.get() == success_counter_before + 1
+    assert error_counter._value.get() == error_counter_before + 1
+    assert success_histogram._sum.get() > success_histogram_before
+    assert error_histogram._sum.get() > error_histogram_before


### PR DESCRIPTION
## Summary
- add Prometheus middleware that records per-route request counters and latency histograms
- register the middleware on the FastAPI app and document the emitted metrics with PromQL examples
- cover the instrumentation with tests exercising success and error responses

## Testing
- `PYTHONPATH=. pytest tests/test_observability_metrics.py`


------
https://chatgpt.com/codex/tasks/task_e_68d7fc342088832aa67cdfeb49427ae5