### PR TITLE
feat: enable requeueing STT DLQ jobs

### DIFF
--- a/apps/mw/src/api/routes/stt_admin.py
+++ b/apps/mw/src/api/routes/stt_admin.py
@@ -1,0 +1,74 @@
+"""Administrative endpoints for managing STT DLQ jobs."""
+from __future__ import annotations
+
+from collections.abc import Generator
+
+from fastapi import APIRouter, Depends, status
+from redis import Redis
+from sqlalchemy.orm import Session
+
+from apps.mw.src.api.dependencies import (
+    ProblemDetailException,
+    build_error,
+    provide_request_id,
+)
+from apps.mw.src.api.schemas import STTDLQRequeueResponse, STTJobPayload
+from apps.mw.src.db.session import get_session
+from apps.mw.src.services.stt_queue import STTQueue, create_redis_client
+
+router = APIRouter(
+    prefix="/api/v1/admin/stt",
+    tags=["admin", "stt"],
+)
+
+
+def _get_stt_queue() -> Generator[STTQueue, None, None]:
+    redis_client: Redis = create_redis_client()
+    queue = STTQueue(redis_client)
+    try:
+        yield queue
+    finally:
+        redis_client.close()
+
+
+@router.post(
+    "/dlq/{entry_id}/requeue",
+    response_model=STTDLQRequeueResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Requeue a Speech-to-Text DLQ entry",
+)
+def requeue_stt_dlq_entry(
+    entry_id: str,
+    *,
+    session: Session = Depends(get_session),
+    queue: STTQueue = Depends(_get_stt_queue),
+    request_id: str = Depends(provide_request_id),
+) -> STTDLQRequeueResponse:
+    """Requeue a DLQ job by identifier returning the restored metadata."""
+
+    entry = queue.requeue_dlq_entry(session, entry_id)
+    if entry is None:
+        raise ProblemDetailException(
+            build_error(
+                status.HTTP_404_NOT_FOUND,
+                title="DLQ entry not found",
+                detail="Requested DLQ entry could not be located.",
+                request_id=request_id,
+            )
+        )
+
+    job = entry.job
+    return STTDLQRequeueResponse(
+        status="requeued",
+        entry_id=entry_id,
+        job=STTJobPayload(
+            record_id=job.record_id,
+            call_id=job.call_id,
+            recording_url=job.recording_url,
+            engine=job.engine,
+            language=job.language,
+        ),
+        reason=entry.reason,
+        failed_at=entry.failed_at,
+        status_code=entry.status_code,
+    )

--- a/apps/mw/src/api/schemas/__init__.py
+++ b/apps/mw/src/api/schemas/__init__.py
@@ -10,6 +10,7 @@ from .returns import (
     ReturnCreateItem,
     ReturnItem,
 )
+from .stt import STTDLQRequeueResponse, STTJobPayload
 
 __all__ = [
     "Error",
@@ -20,4 +21,6 @@ __all__ = [
     "ReturnCreate",
     "ReturnCreateItem",
     "ReturnItem",
+    "STTDLQRequeueResponse",
+    "STTJobPayload",
 ]

--- a/apps/mw/src/api/schemas/stt.py
+++ b/apps/mw/src/api/schemas/stt.py
@@ -1,0 +1,28 @@
+"""Schemas for STT administration endpoints."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel
+
+
+class STTJobPayload(BaseModel):
+    """Serialized representation of a Speech-to-Text job."""
+
+    record_id: int
+    call_id: str
+    recording_url: str
+    engine: str
+    language: str | None = None
+
+
+class STTDLQRequeueResponse(BaseModel):
+    """Response returned after successfully requeueing a DLQ job."""
+
+    status: Literal["requeued"]
+    entry_id: str
+    job: STTJobPayload
+    reason: str
+    failed_at: datetime
+    status_code: int | None = None

--- a/apps/mw/src/app.py
+++ b/apps/mw/src/app.py
@@ -16,6 +16,7 @@ from apps.mw.src.api.dependencies import (
 from apps.mw.src.api.routes import b24_calls as b24_calls_router
 from apps.mw.src.api.routes import call_registry as call_registry_router
 from apps.mw.src.api.routes import returns as returns_router
+from apps.mw.src.api.routes import stt_admin as stt_admin_router
 from apps.mw.src.api.routes import system as system_router
 from apps.mw.src.api.schemas import Error, Health
 from apps.mw.src.health import get_health_payload
@@ -35,6 +36,7 @@ app.include_router(system_router.router)
 app.include_router(b24_calls_router.router)
 app.include_router(call_registry_router.router)
 app.include_router(returns_router.router)
+app.include_router(stt_admin_router.router)
 
 
 @app.get("/health", response_model=Health)

--- a/tests/services/test_stt_queue_dlq.py
+++ b/tests/services/test_stt_queue_dlq.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import datetime, timezone
+
+from sqlalchemy import Column, Table, create_engine, event
+from sqlalchemy.dialects.postgresql import UUID as PGUUID
+from sqlalchemy.orm import Session
+
+from apps.mw.src.db.models import (
+    Base,
+    CallDirection,
+    CallExport,
+    CallExportStatus,
+    CallRecord,
+    CallRecordStatus,
+)
+from apps.mw.src.services.stt_queue import DLQEntry, STTJob, STTQueue, STT_PROCESSED_KEY
+
+
+class _FakeRedis:
+    """Minimal in-memory Redis replacement used for queue tests."""
+
+    def __init__(self) -> None:
+        self._lists: defaultdict[str, list[str]] = defaultdict(list)
+        self._sets: defaultdict[str, set[str]] = defaultdict(set)
+
+    def rpush(self, key: str, value: str) -> int:
+        self._lists[key].append(value)
+        return len(self._lists[key])
+
+    def lpop(self, key: str) -> str | None:
+        values = self._lists.get(key)
+        if not values:
+            return None
+        return values.pop(0)
+
+    def blpop(self, keys: list[str], timeout: int = 0) -> tuple[str, str] | None:
+        for key in keys:
+            item = self.lpop(key)
+            if item is not None:
+                return key, item
+        return None
+
+    def lrange(self, key: str, start: int, stop: int) -> list[str]:
+        values = list(self._lists.get(key, []))
+        length = len(values)
+        if length == 0:
+            return []
+
+        if start < 0:
+            start = max(length + start, 0)
+        if stop < 0:
+            stop = length + stop
+        stop = min(stop, length - 1)
+        if start > stop:
+            return []
+        return values[start : stop + 1]
+
+    def lrem(self, key: str, count: int, value: str) -> int:
+        values = self._lists.get(key, [])
+        if not values:
+            return 0
+
+        removed = 0
+        if count == 0:
+            new_values = [item for item in values if item != value]
+            removed = len(values) - len(new_values)
+            self._lists[key] = new_values
+            return removed
+
+        new_values: list[str] = []
+        for item in values:
+            if item == value and removed < count:
+                removed += 1
+                continue
+            new_values.append(item)
+        self._lists[key] = new_values
+        return removed
+
+    def sadd(self, key: str, value: str) -> int:
+        before = len(self._sets[key])
+        self._sets[key].add(value)
+        return int(len(self._sets[key]) > before)
+
+    def sismember(self, key: str, value: str) -> bool:
+        return value in self._sets[key]
+
+    def srem(self, key: str, value: str) -> int:
+        if value in self._sets[key]:
+            self._sets[key].remove(value)
+            return 1
+        return 0
+
+
+def _sqlite_engine():
+    engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+
+    @event.listens_for(engine, "connect")
+    def _set_sqlite_pragma(dbapi_connection, connection_record):  # pragma: no cover - sqlite hook
+        cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+
+    return engine
+
+
+def _ensure_core_users_table() -> Table:
+    if "core.users" in Base.metadata.tables:
+        return Base.metadata.tables["core.users"]
+    return Table(
+        "core.users",
+        Base.metadata,
+        Column("user_id", PGUUID(as_uuid=True), primary_key=True),
+    )
+
+
+def test_requeue_dlq_entry_resets_state_and_requeues_job() -> None:
+    engine = _sqlite_engine()
+    core_users = _ensure_core_users_table()
+    Base.metadata.create_all(
+        engine,
+        tables=[core_users, CallExport.__table__, CallRecord.__table__],
+    )
+
+    redis = _FakeRedis()
+    queue = STTQueue(redis)
+
+    now = datetime.now(timezone.utc)
+    with Session(engine) as session:
+        export = CallExport(
+            period_from=now,
+            period_to=now,
+            status=CallExportStatus.PENDING,
+            options=None,
+        )
+        record = CallRecord(
+            export=export,
+            call_id="CALL-123",
+            direction=CallDirection.INBOUND,
+            from_number="123",
+            to_number="456",
+            duration_sec=60,
+            status=CallRecordStatus.ERROR,
+            recording_url="https://example.com/call.wav",
+            error_code="stt_failed",
+            error_message="timeout",
+        )
+        session.add_all([export, record])
+        session.commit()
+        record_id = record.id
+
+    job = STTJob(
+        record_id=record_id,
+        call_id="CALL-123",
+        recording_url="https://example.com/call.wav",
+        engine="whisper",  # pragma: allowlist secret
+        language="ru",
+    )
+    queue.mark_processed(job)
+    dlq_entry = DLQEntry(job=job, reason="transcription failed", status_code=500)
+    queue.push_to_dlq(dlq_entry)
+
+    entries = queue.list_dlq_entries()
+    assert len(entries) == 1
+    entry_id = entries[0].entry_id
+
+    with Session(engine) as session:
+        restored_entry = queue.requeue_dlq_entry(session, entry_id)
+        assert restored_entry is not None
+        assert restored_entry.reason == "transcription failed"
+
+        record = session.get(CallRecord, record_id)
+        assert record is not None
+        assert record.status is CallRecordStatus.DOWNLOADED
+        assert record.error_code is None
+        assert record.error_message is None
+
+    assert queue.list_dlq_entries() == []
+    assert not redis.sismember(STT_PROCESSED_KEY, job.dedup_key)
+
+    fetched = queue.fetch_job(timeout=0)
+    assert fetched == job
+    assert queue.fetch_job(timeout=0) is None
+
+    engine.dispose()


### PR DESCRIPTION
## Summary
- extend the STT queue helper with DLQ listing/pop helpers, processed marker reset, and retry preparation
- cover the DLQ requeue path with unit tests to ensure the processed marker is cleared and the job can be fetched again
- expose a new admin API route and schemas to requeue DLQ entries via HTTP and wire it into the application router

## Testing
- PYTHONPATH=. pytest tests/services/test_stt_queue_dlq.py

------
https://chatgpt.com/codex/tasks/task_e_68d802c193e0832abeb21fa0e96aff75