### PR TITLE
feat: secure STT DLQ replay with audit logging

### DIFF
--- a/apps/mw/migrations/versions/0007_audit_log.py
+++ b/apps/mw/migrations/versions/0007_audit_log.py
@@ -1,0 +1,56 @@
+"""Create audit_log table for administrative actions."""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.dialects.sqlite import JSON as SQLiteJSON
+
+# revision identifiers, used by Alembic.
+revision = "0007_audit_log"
+down_revision = (
+    "0006_call_records_add_employee_text_preview",
+    "0006_call_records_unique_recording_url",
+)
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    json_type = JSONB().with_variant(SQLiteJSON(), "sqlite")
+
+    op.create_table(
+        "audit_log",
+        sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column("actor", sa.String(length=128), nullable=False),
+        sa.Column("action", sa.String(length=64), nullable=False),
+        sa.Column("job_reference", sa.Text(), nullable=False),
+        sa.Column("job_payload", json_type, nullable=False),
+        sa.Column("reason", sa.Text(), nullable=False),
+        sa.CheckConstraint(
+            "length(trim(actor)) > 0",
+            name="chk_audit_log_actor_not_blank",
+        ),
+        sa.CheckConstraint(
+            "length(trim(action)) > 0",
+            name="chk_audit_log_action_not_blank",
+        ),
+        sa.CheckConstraint(
+            "length(trim(job_reference)) > 0",
+            name="chk_audit_log_job_reference_not_blank",
+        ),
+        sa.CheckConstraint(
+            "length(trim(reason)) > 0",
+            name="chk_audit_log_reason_not_blank",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("audit_log")

--- a/apps/mw/src/api/routes/stt.py
+++ b/apps/mw/src/api/routes/stt.py
@@ -1,0 +1,57 @@
+"""Speech-to-Text queue administration endpoints."""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, status
+from sqlalchemy.orm import Session
+
+from apps.mw.src.api.dependencies import (
+    ProblemDetailException,
+    build_error,
+    provide_request_id,
+    require_admin_actor,
+)
+from apps.mw.src.api.schemas import DLQReplayRequest, DLQReplayResponse
+from apps.mw.src.db.session import get_session
+from apps.mw.src.services.audit import AuditLogService
+from apps.mw.src.services.stt_queue import STTQueue, create_redis_client
+
+router = APIRouter(
+    prefix="/api/v1/stt",
+    tags=["stt"],
+    dependencies=[Depends(provide_request_id)],
+)
+
+
+def get_stt_queue() -> STTQueue:
+    """FastAPI dependency returning a queue instance."""
+
+    client = create_redis_client()
+    return STTQueue(client)
+
+
+@router.post(
+    "/dlq/replay",
+    response_model=DLQReplayResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+    summary="Replay an STT job from the DLQ",
+)
+async def replay_dlq_job(
+    payload: DLQReplayRequest,
+    actor: str = Depends(require_admin_actor),
+    queue: STTQueue = Depends(get_stt_queue),
+    session: Session = Depends(get_session),
+) -> DLQReplayResponse:
+    """Requeue a specific STT job from the DLQ and log the action."""
+
+    job = queue.replay_dlq_job(payload.record_id)
+    if job is None:
+        raise ProblemDetailException(
+            build_error(
+                status.HTTP_404_NOT_FOUND,
+                title="DLQ job not found",
+                detail="Requested job is not present in the DLQ.",
+            )
+        )
+
+    AuditLogService(session).log_dlq_replay(actor=actor, job=job, reason=payload.reason)
+    return DLQReplayResponse(status="requeued", job=job.to_payload())

--- a/apps/mw/src/api/schemas/__init__.py
+++ b/apps/mw/src/api/schemas/__init__.py
@@ -10,12 +10,15 @@ from .returns import (
     ReturnCreateItem,
     ReturnItem,
 )
+from .stt import DLQReplayRequest, DLQReplayResponse
 
 __all__ = [
     "Error",
     "Health",
     "PaginatedReturns",
     "Ping",
+    "DLQReplayRequest",
+    "DLQReplayResponse",
     "Return",
     "ReturnCreate",
     "ReturnCreateItem",

--- a/apps/mw/src/api/schemas/stt.py
+++ b/apps/mw/src/api/schemas/stt.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class STTAPIModel(BaseModel):
+    """Base schema for STT-related payloads."""
+
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
+
+
+class DLQReplayRequest(STTAPIModel):
+    """Request payload for replaying a job from the DLQ."""
+
+    record_id: int = Field(
+        ge=1,
+        description="Identifier of the call record associated with the STT job.",
+    )
+    reason: str = Field(
+        min_length=1,
+        max_length=1024,
+        description="Operator provided reason for replaying the job.",
+    )
+
+
+class DLQReplayResponse(STTAPIModel):
+    """Response body confirming that a DLQ job was replayed."""
+
+    status: str = Field(description="Outcome of the replay request.")
+    job: dict[str, Any] = Field(
+        description="Payload of the STT job that was re-enqueued.",
+    )

--- a/apps/mw/src/app.py
+++ b/apps/mw/src/app.py
@@ -16,6 +16,7 @@ from apps.mw.src.api.dependencies import (
 from apps.mw.src.api.routes import b24_calls as b24_calls_router
 from apps.mw.src.api.routes import call_registry as call_registry_router
 from apps.mw.src.api.routes import returns as returns_router
+from apps.mw.src.api.routes import stt as stt_router
 from apps.mw.src.api.routes import system as system_router
 from apps.mw.src.api.schemas import Error, Health
 from apps.mw.src.health import get_health_payload
@@ -35,6 +36,7 @@ app.include_router(system_router.router)
 app.include_router(b24_calls_router.router)
 app.include_router(call_registry_router.router)
 app.include_router(returns_router.router)
+app.include_router(stt_router.router)
 
 
 @app.get("/health", response_model=Health)

--- a/apps/mw/src/config/settings.py
+++ b/apps/mw/src/config/settings.py
@@ -35,6 +35,8 @@ class Settings(BaseSettings):
     worker_metrics_host: str = Field(default="0.0.0.0", alias="WORKER_METRICS_HOST")
     worker_metrics_port: int = Field(default=9100, alias="WORKER_METRICS_PORT")
 
+    admin_api_key: str | None = Field(default=None, alias="ADMIN_API_KEY")
+
     b24_base_url: str = Field(default="https://example.bitrix24.ru/rest", alias="B24_BASE_URL")
     b24_webhook_user_id: int = Field(default=1, alias="B24_WEBHOOK_USER_ID")
     b24_webhook_token: str = Field(default="changeme", alias="B24_WEBHOOK_TOKEN")

--- a/apps/mw/src/db/models.py
+++ b/apps/mw/src/db/models.py
@@ -473,3 +473,39 @@ class CallRecord(Base):
     )
 
     export: Mapped[CallExport] = relationship(back_populates="records")
+
+
+class AuditLog(Base):
+    """Audit trail entry capturing administrative actions."""
+
+    __tablename__ = "audit_log"
+    __table_args__ = (
+        CheckConstraint(
+            "length(trim(actor)) > 0",
+            name="chk_audit_log_actor_not_blank",
+        ),
+        CheckConstraint(
+            "length(trim(action)) > 0",
+            name="chk_audit_log_action_not_blank",
+        ),
+        CheckConstraint(
+            "length(trim(job_reference)) > 0",
+            name="chk_audit_log_job_reference_not_blank",
+        ),
+        CheckConstraint(
+            "length(trim(reason)) > 0",
+            name="chk_audit_log_reason_not_blank",
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+    actor: Mapped[str] = mapped_column(String(128), nullable=False)
+    action: Mapped[str] = mapped_column(String(64), nullable=False)
+    job_reference: Mapped[str] = mapped_column(Text, nullable=False)
+    job_payload: Mapped[dict[str, Any]] = mapped_column(JSONBType, nullable=False)
+    reason: Mapped[str] = mapped_column(Text, nullable=False)

--- a/apps/mw/src/services/__init__.py
+++ b/apps/mw/src/services/__init__.py
@@ -1,6 +1,12 @@
 """Service layer helpers for the middleware application."""
 
+from .audit import AuditLogService
 from .call_download import download_call_record
 from .storage import StorageResult, StorageService
 
-__all__ = ["download_call_record", "StorageResult", "StorageService"]
+__all__ = [
+    "AuditLogService",
+    "download_call_record",
+    "StorageResult",
+    "StorageService",
+]

--- a/apps/mw/src/services/audit.py
+++ b/apps/mw/src/services/audit.py
@@ -1,0 +1,56 @@
+"""Persistence helpers for audit logging."""
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy.orm import Session
+
+from apps.mw.src.db.models import AuditLog
+from apps.mw.src.services.stt_queue import STTJob
+ 
+ 
+class AuditLogRepository:
+    """Simple repository responsible for persisting audit entries."""
+
+    def __init__(self, session: Session) -> None:
+        self._session = session
+
+    def create(
+        self,
+        *,
+        actor: str,
+        action: str,
+        job_reference: str,
+        job_payload: dict[str, Any],
+        reason: str,
+    ) -> AuditLog:
+        entry = AuditLog(
+            actor=actor,
+            action=action,
+            job_reference=job_reference,
+            job_payload=job_payload,
+            reason=reason,
+        )
+        self._session.add(entry)
+        self._session.commit()
+        self._session.refresh(entry)
+        return entry
+
+
+class AuditLogService:
+    """High level service for writing audit trail events."""
+
+    def __init__(self, session: Session) -> None:
+        self._repository = AuditLogRepository(session)
+
+    def log_dlq_replay(self, *, actor: str, job: STTJob, reason: str) -> AuditLog:
+        """Persist a DLQ replay event describing the affected job."""
+
+        payload = job.to_payload()
+        return self._repository.create(
+            actor=actor,
+            action="stt_dlq_replay",
+            job_reference=str(job.record_id),
+            job_payload=payload,
+            reason=reason,
+        )

--- a/tests/test_stt_dlq_api.py
+++ b/tests/test_stt_dlq_api.py
@@ -1,0 +1,155 @@
+"""Tests for the STT DLQ replay administrative endpoint."""
+from __future__ import annotations
+
+from typing import AsyncIterator, Iterator
+
+import httpx
+import pytest
+import pytest_asyncio
+from sqlalchemy import create_engine
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import Session
+from sqlalchemy.pool import StaticPool
+
+from apps.mw.src.app import app
+from apps.mw.src.api.routes.stt import get_stt_queue
+from apps.mw.src.config import get_settings
+from apps.mw.src.db.models import AuditLog
+from apps.mw.src.db.session import configure_engine, engine as default_engine, get_session
+from apps.mw.src.services.stt_queue import STTJob
+
+BASE_URL = "http://testserver"
+ADMIN_KEY = "super-secret-admin"
+
+
+class FakeQueue:
+    """Minimal fake of the STT queue for testing DLQ replay."""
+
+    def __init__(self) -> None:
+        self._jobs: dict[int, STTJob] = {}
+        self.replayed: list[int] = []
+
+    def add(self, job: STTJob) -> None:
+        self._jobs[job.record_id] = job
+
+    def replay_dlq_job(self, record_id: int) -> STTJob | None:
+        job = self._jobs.get(record_id)
+        if job is None:
+            return None
+        self.replayed.append(record_id)
+        return job
+
+
+@pytest.fixture(autouse=True)
+def _configure_admin_key(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("ADMIN_API_KEY", ADMIN_KEY)
+    get_settings.cache_clear()
+    try:
+        yield
+    finally:
+        get_settings.cache_clear()
+
+
+@pytest.fixture()
+def fake_queue() -> FakeQueue:
+    queue = FakeQueue()
+    queue.add(
+        STTJob(
+            record_id=123,
+            call_id="call-123",
+            recording_url="https://example.com/recording.mp3",
+            engine="whisper",
+            language="ru",
+        )
+    )
+    return queue
+
+
+@pytest.fixture()
+def sqlite_engine() -> Engine:
+    engine = create_engine(
+        "sqlite+pysqlite:///:memory:",
+        future=True,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    AuditLog.__table__.create(bind=engine, checkfirst=True)
+    configure_engine(engine)
+    try:
+        yield engine
+    finally:
+        configure_engine(default_engine)
+        engine.dispose()
+
+
+@pytest_asyncio.fixture()
+async def api_client(sqlite_engine: Engine, fake_queue: FakeQueue) -> AsyncIterator[httpx.AsyncClient]:
+    def override_get_session() -> Iterator[Session]:
+        session = Session(bind=sqlite_engine)
+        try:
+            yield session
+        finally:
+            session.close()
+
+    app.dependency_overrides[get_session] = override_get_session
+    app.dependency_overrides[get_stt_queue] = lambda: fake_queue
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url=BASE_URL) as client:
+        yield client
+
+    app.dependency_overrides.pop(get_session, None)
+    app.dependency_overrides.pop(get_stt_queue, None)
+
+
+@pytest.mark.asyncio
+async def test_dlq_replay_requires_admin_credentials(
+    api_client: httpx.AsyncClient,
+) -> None:
+    payload = {"record_id": 123, "reason": "manual replay"}
+
+    missing_auth = await api_client.post("/api/v1/stt/dlq/replay", json=payload)
+    assert missing_auth.status_code == 401
+    assert missing_auth.json()["title"] == "Unauthorized"
+
+    wrong_auth = await api_client.post(
+        "/api/v1/stt/dlq/replay",
+        json=payload,
+        headers={"Authorization": "Bearer invalid"},
+    )
+    assert wrong_auth.status_code == 401
+    assert wrong_auth.json()["title"] == "Unauthorized"
+
+
+@pytest.mark.asyncio
+async def test_dlq_replay_logs_audit_entry(
+    api_client: httpx.AsyncClient,
+    sqlite_engine: Engine,
+    fake_queue: FakeQueue,
+) -> None:
+    headers = {
+        "Authorization": f"Bearer {ADMIN_KEY}",
+        "X-Admin-Actor": "operator-1",
+    }
+    payload = {"record_id": 123, "reason": "Manual retry after fix"}
+
+    response = await api_client.post("/api/v1/stt/dlq/replay", json=payload, headers=headers)
+    assert response.status_code == 202
+    body = response.json()
+    assert body["status"] == "requeued"
+    assert body["job"]["record_id"] == 123
+    assert fake_queue.replayed == [123]
+
+    session = Session(bind=sqlite_engine)
+    try:
+        entries = session.query(AuditLog).all()
+    finally:
+        session.close()
+
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry.actor == "operator-1"
+    assert entry.action == "stt_dlq_replay"
+    assert entry.job_reference == "123"
+    assert entry.reason == "Manual retry after fix"
+    assert entry.job_payload["call_id"] == "call-123"


### PR DESCRIPTION
## Summary
- add an admin API-key dependency and guard the STT DLQ replay endpoint
- persist DLQ replay attempts through a new audit_log table and service
- cover authorization failures and audit logging behaviour with FastAPI tests

## Testing
- PYTHONPATH=. pytest tests/test_stt_dlq_api.py *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*

------
https://chatgpt.com/codex/tasks/task_e_68d802c4a140832aa3bc88d5e1d3ad98