### PR TITLE
fix: sanitize storage keys for call recordings

### DIFF
--- a/apps/mw/src/services/storage.py
+++ b/apps/mw/src/services/storage.py
@@ -304,6 +304,7 @@ class StorageService:
         else:
             day = datetime.now(tz=UTC).date()
 
+        sanitized_call_id = self._sanitize_identifier(call_id)
         suffix = self._sanitize_identifier(record_identifier)
 
         return str(
@@ -311,7 +312,7 @@ class StorageService:
             / f"{day.year:04d}"
             / f"{day.month:02d}"
             / f"{day.day:02d}"
-            / f"call_{call_id}_{suffix}.mp3"
+            / f"call_{sanitized_call_id}_{suffix}.mp3"
         )
 
     def _build_summary_key(self, call_id: str, created_at: datetime) -> str:


### PR DESCRIPTION
## Summary
- sanitize call identifiers before embedding them into raw storage keys
- prevent crafted call IDs from traversing outside the storage root by extending coverage

## Testing
- PYTHONPATH=. pytest tests/test_b24_download.py::test_storage_local_sanitizes_call_id_path

------
https://chatgpt.com/codex/tasks/task_e_68d8f5a45d54832aa95546a1c545b820