### PR TITLE
ci: add docs quality checks

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,3 @@
+[codespell]
+skip = ./.git,./.venv,./build,./dist,./docs/testing/error_catalog.json
+ignore-words-list = masterdata,mastermobile,redis

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,3 +59,32 @@ jobs:
           name: stt-smoke-report
           path: ${{ steps.stt-smoke.outputs.report_path }}
           if-no-files-found: warn
+
+  docs-quality:
+    name: Docs quality
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install documentation tooling
+        run: make init
+
+      - name: Markdownlint
+        run: make docs-markdownlint
+
+      - name: Link checker
+        run: make docs-links
+
+      - name: Spellcheck
+        run: make docs-spellcheck
+
+      - name: Docs CI smoke test
+        run: make docs-ci-smoke

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -1,0 +1,33 @@
+# Configuration for the lychee link checker used in CI.
+# Reference: https://github.com/lycheeverse/lychee
+
+verbose = "info"
+no_progress = true
+cache = true
+max_cache_age = "1d"
+max_redirects = 10
+max_retries = 2
+retry_wait_time = 2
+timeout = 20
+user_agent = "mastermobile-docs-ci/1.0"
+accept = ["200", "206", "429"]
+include_verbatim = false
+include_mail = true
+scheme = ["http", "https", "mailto"]
+require_https = false
+
+# Skip generated directories and local cache folders that may contain
+# machine-specific links when running locally.
+exclude_path = [
+  "^\\.git/",
+  "^\\.venv/",
+  "^build/",
+  "^dist/"
+]
+
+# Ignore localhost references that are only valid in developer environments.
+exclude = [
+  "^https?://localhost",
+  "^https?://127\\.0\\.0\\.1",
+  "^https?://0\\.0\\.0\\.0"
+]

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,0 +1,32 @@
+# Markdownlint configuration for MasterMobile docs CI
+# See https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md
+# for rule reference.
+
+# Enable all default rules, then selectively customize exceptions.
+default: true
+
+# Allow long lines in tables and code examples.
+MD013:
+  line_length: 120
+  heading_line_length: 120
+  code_block_line_length: 120
+  tables: false
+
+# Permit inline HTML for diagrams and complex embeds.
+MD033: false
+
+# Allow documents without an initial top-level heading (handled manually).
+MD041: false
+
+# Enforce dash-style unordered lists.
+MD004:
+  style: dash
+
+# Allow duplicate headings only across different sections with same parent.
+MD024:
+  siblings_only: true
+
+# Ensure fenced code blocks always specify a language when practical but
+# keep compatibility with legacy snippets.
+MD040:
+  code_blocks: true

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-.PHONY: init up down logs lint typecheck test fmt openapi db-upgrade db-downgrade run seed worker
+.PHONY: init up down logs lint typecheck test fmt openapi db-upgrade db-downgrade run seed worker \
+	docs-markdownlint docs-links docs-spellcheck docs-ci docs-ci-smoke
 
 VENV_DIR := .venv
 VENV_BIN := $(VENV_DIR)/bin
@@ -8,11 +9,16 @@ RUFF := $(VENV_BIN)/ruff
 MYPY := $(VENV_BIN)/mypy
 PYTEST := $(VENV_BIN)/pytest
 VENV_SENTINEL := $(VENV_DIR)/.initialized
+MARKDOWNLINT_IMAGE := ghcr.io/igorshubovych/markdownlint-cli:0.39.0
+LYCHEE_IMAGE := ghcr.io/lycheeverse/lychee:latest
+MARKDOWNLINT_TARGETS ?= '**/*.md'
+LYCHEE_TARGETS ?= README.md docs/
+DOCS_SMOKE_DIR := build/docs-ci-smoke
 
 init: $(VENV_SENTINEL)
 
 $(VENV_SENTINEL): pyproject.toml
-	test -d $(VENV_DIR) || python -m venv $(VENV_DIR)
+	@test -d $(VENV_DIR) || python -m venv $(VENV_DIR)
 	$(PIP) install --upgrade pip
 	$(PIP) install -e ".[dev]"
 	touch $(VENV_SENTINEL)
@@ -37,6 +43,41 @@ typecheck: $(VENV_SENTINEL)
 
 test: $(VENV_SENTINEL)
 	$(PYTEST)
+
+docs-markdownlint:
+	docker run --rm -v "$(CURDIR)":/workdir -w /workdir $(MARKDOWNLINT_IMAGE) \
+	  --config .markdownlint.yml $(MARKDOWNLINT_TARGETS)
+
+docs-links:
+	docker run --rm -v "$(CURDIR)":/workdir -w /workdir $(LYCHEE_IMAGE) \
+	  --config /workdir/.lychee.toml --no-progress $(LYCHEE_TARGETS)
+
+docs-spellcheck: $(VENV_SENTINEL)
+	$(VENV_BIN)/codespell --config .codespellrc --check-hidden --check-filenames
+
+docs-ci: docs-markdownlint docs-links docs-spellcheck
+
+docs-ci-smoke:
+	command -v docker >/dev/null 2>&1 || { echo "Docker is required for docs-ci-smoke." >&2; exit 2; }
+	rm -rf "$(DOCS_SMOKE_DIR)"
+	mkdir -p "$(DOCS_SMOKE_DIR)"
+	printf '# Docs CI smoke test\n\n# This temporary file ensures lychee fails on an unreachable link.\n\n[broken](https://example.invalid/mastermobile-smoke)\n' > "$(DOCS_SMOKE_DIR)/broken.md"
+	$(MAKE) --no-print-directory docs-links LYCHEE_TARGETS="$(DOCS_SMOKE_DIR)/broken.md" > "$(DOCS_SMOKE_DIR)/lychee.log" 2>&1; \
+	status=$$?; \
+	if [ $$status -eq 0 ]; then \
+		cat "$(DOCS_SMOKE_DIR)/lychee.log"; \
+		echo "Expected docs-links to fail when checking a broken URL." >&2; \
+		rm -rf "$(DOCS_SMOKE_DIR)"; \
+		exit 1; \
+	elif ! grep -q 'example.invalid/mastermobile-smoke' "$(DOCS_SMOKE_DIR)/lychee.log"; then \
+		cat "$(DOCS_SMOKE_DIR)/lychee.log"; \
+		echo "docs-links failed but did not report the smoke link; check the environment." >&2; \
+		rm -rf "$(DOCS_SMOKE_DIR)"; \
+		exit 1; \
+	else \
+		rm -rf "$(DOCS_SMOKE_DIR)"; \
+		echo "Lychee correctly detected a broken link."; \
+	fi
 
 openapi:
 	@echo "OpenAPI: ./openapi.yaml"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # MasterMobile — Middleware & Integrations (FastAPI)
 
+[![CI](https://github.com/Offonika/mastermobile/actions/workflows/ci.yml/badge.svg)](https://github.com/Offonika/mastermobile/actions/workflows/ci.yml)
 [![Docs CI](https://github.com/Offonika/mastermobile/actions/workflows/docs-ci.yml/badge.svg)](https://github.com/Offonika/mastermobile/actions/workflows/docs-ci.yml)
 
 ## Что это
@@ -20,6 +21,21 @@
 > Для запуска только зависимостей можно выполнить `docker compose up -d db redis`.
 > Метрики Prometheus для FastAPI-приложения доступны по адресу `http://localhost:8000/metrics`.
 > Экспортер фонового STT-воркера публикует метрики на `http://localhost:${WORKER_METRICS_PORT:-9100}/metrics`.
+
+## CI и Docs-CI
+
+Основной workflow [`ci.yml`](.github/workflows/ci.yml) запускает два набора проверок:
+
+- **Quality** — Python-инструменты (`make lint`, `make typecheck`, `make test` и STT smoke-плейлист при наличии ключей).
+- **Docs quality** — проверки документации и ссылок: `make docs-markdownlint`, `make docs-links`, `make docs-spellcheck` и смоук-тест `make docs-ci-smoke`, который подтверждает, что link-checker корректно ловит ошибочные URL.
+
+Для локального запуска docs-проверок доступны команды Makefile:
+
+- `make docs-markdownlint` — проверка Markdown по правилам из `.markdownlint.yml` (использует контейнер `ghcr.io/igorshubovych/markdownlint-cli`).
+- `make docs-links` — сканирование ссылок через `lychee` с конфигом `.lychee.toml` (контейнер `ghcr.io/lycheeverse/lychee`).
+- `make docs-spellcheck` — орфография через `codespell` c параметрами из `.codespellrc`.
+- `make docs-ci` — последовательный запуск всех проверок.
+- `make docs-ci-smoke` — временно создаёт тестовый markdown с «битой» ссылкой и убеждается, что `lychee` падает с ошибкой.
 
 ## Smoke-тест распознавания речи
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
+    "codespell>=2.3",
     "mypy>=1.11",
     "pytest>=8.2",
     "pytest-asyncio>=0.23",


### PR DESCRIPTION
## Summary
- add a docs-quality job to the main CI workflow to run markdownlint, lychee, codespell, and a smoke test
- provide Makefile targets plus configuration for the new documentation tooling
- document the docs checks in the README and expose a CI badge

## Testing
- make init
- make docs-spellcheck

------
https://chatgpt.com/codex/tasks/task_e_68d8fc486820832aba95846ca51e7898