### PR TITLE
Add Bitrix24 transcript storage and search

### DIFF
--- a/apps/mw/migrations/versions/0007_b24_transcripts.py
+++ b/apps/mw/migrations/versions/0007_b24_transcripts.py
@@ -1,0 +1,67 @@
+"""Create table for Bitrix24 transcripts."""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.dialects.sqlite import JSON as SQLiteJSON
+
+# revision identifiers, used by Alembic.
+revision = "0007_b24_transcripts"
+down_revision = "0006_call_records_unique_recording_url"
+branch_labels = None
+depends_on = ("0006_call_records_add_employee_text_preview",)
+
+
+def upgrade() -> None:
+    op.create_table(
+        "b24_transcripts",
+        sa.Column("id", sa.BigInteger().with_variant(sa.Integer, "sqlite"), primary_key=True, autoincrement=True),
+        sa.Column(
+            "call_record_id",
+            sa.BigInteger().with_variant(sa.Integer, "sqlite"),
+            sa.ForeignKey("call_records.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("text_full", sa.Text(), nullable=False),
+        sa.Column("text_normalized", sa.Text(), nullable=True),
+        sa.Column("metadata", JSONB().with_variant(SQLiteJSON(), "sqlite"), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+            server_onupdate=sa.func.now(),
+        ),
+    )
+    op.create_index(
+        "uq_b24_transcripts_call_record_id",
+        "b24_transcripts",
+        ["call_record_id"],
+        unique=True,
+    )
+
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        op.execute(
+            """
+            CREATE INDEX ix_b24_transcripts_text_full_fts
+            ON b24_transcripts
+            USING GIN (to_tsvector('russian', text_full))
+            """
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        op.execute("DROP INDEX IF EXISTS ix_b24_transcripts_text_full_fts")
+
+    op.drop_index("uq_b24_transcripts_call_record_id", table_name="b24_transcripts")
+    op.drop_table("b24_transcripts")

--- a/apps/mw/src/db/models.py
+++ b/apps/mw/src/db/models.py
@@ -473,3 +473,48 @@ class CallRecord(Base):
     )
 
     export: Mapped[CallExport] = relationship(back_populates="records")
+    transcript: Mapped["B24Transcript | None"] = relationship(
+        back_populates="call_record",
+        cascade="all, delete-orphan",
+        uselist=False,
+    )
+
+
+class B24Transcript(Base):
+    """Full text transcript linked to a Bitrix24 call record."""
+
+    __tablename__ = "b24_transcripts"
+    __table_args__ = (
+        Index("uq_b24_transcripts_call_record_id", "call_record_id", unique=True),
+    )
+
+    id: Mapped[int] = mapped_column(
+        BigInteger().with_variant(Integer, "sqlite"),
+        primary_key=True,
+        autoincrement=True,
+    )
+    call_record_id: Mapped[int] = mapped_column(
+        BigInteger().with_variant(Integer, "sqlite"),
+        ForeignKey("call_records.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    text_full: Mapped[str] = mapped_column(Text, nullable=False)
+    text_normalized: Mapped[str | None] = mapped_column(Text, nullable=True)
+    metadata_json: Mapped[dict[str, Any] | None] = mapped_column(
+        "metadata",
+        JSONBType,
+        nullable=True,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+    call_record: Mapped[CallRecord] = relationship(back_populates="transcript")

--- a/apps/mw/src/db/repositories/__init__.py
+++ b/apps/mw/src/db/repositories/__init__.py
@@ -1,0 +1,5 @@
+"""Repository helpers for database access patterns."""
+
+from .transcripts import B24TranscriptRepository, B24TranscriptSearchResult
+
+__all__ = ["B24TranscriptRepository", "B24TranscriptSearchResult"]

--- a/apps/mw/src/db/repositories/transcripts.py
+++ b/apps/mw/src/db/repositories/transcripts.py
@@ -1,0 +1,194 @@
+"""Data access helpers for Bitrix24 call transcripts."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from sqlalchemy import Select, func, select, text
+from sqlalchemy.orm import Session
+
+from apps.mw.src.db.models import B24Transcript
+
+
+@dataclass(slots=True)
+class B24TranscriptSearchResult:
+    """Search match returned by :class:`B24TranscriptRepository`."""
+
+    transcript: B24Transcript
+    snippet: str
+    score: float | None = None
+
+
+class B24TranscriptRepository:
+    """CRUD helpers around the :class:`~apps.mw.src.db.models.B24Transcript` model."""
+
+    _HIGHLIGHT_OPTIONS = "StartSel=<mark>,StopSel=</mark>,MaxFragments=1,ShortWord=2,MaxWords=30"
+
+    def __init__(self, session: Session) -> None:
+        self._session = session
+
+    def create(
+        self,
+        *,
+        call_record_id: int,
+        text_full: str,
+        text_normalized: str | None = None,
+        metadata: dict[str, object] | None = None,
+    ) -> B24Transcript:
+        """Persist a new transcript for the given call record."""
+
+        transcript = B24Transcript(
+            call_record_id=call_record_id,
+            text_full=text_full,
+            text_normalized=text_normalized,
+            metadata_json=metadata,
+        )
+        self._session.add(transcript)
+        self._session.flush()
+        return transcript
+
+    def get_by_call_record_id(self, call_record_id: int) -> B24Transcript | None:
+        """Return a transcript bound to the provided call record, if any."""
+
+        statement: Select[tuple[B24Transcript]] = select(B24Transcript).where(
+            B24Transcript.call_record_id == call_record_id
+        )
+        return self._session.scalar(statement)
+
+    def update(
+        self,
+        transcript: B24Transcript,
+        *,
+        text_full: str | None = None,
+        text_normalized: str | None = None,
+        metadata: dict[str, object] | None = None,
+    ) -> B24Transcript:
+        """Update text fields or metadata on an existing transcript."""
+
+        if text_full is not None:
+            transcript.text_full = text_full
+        if text_normalized is not None:
+            transcript.text_normalized = text_normalized
+        if metadata is not None:
+            transcript.metadata_json = metadata
+        self._session.flush()
+        return transcript
+
+    def delete(self, transcript: B24Transcript) -> None:
+        """Remove a transcript and flush the session immediately."""
+
+        self._session.delete(transcript)
+        self._session.flush()
+
+    def search(
+        self,
+        query: str,
+        *,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> list[B24TranscriptSearchResult]:
+        """Search transcripts using PostgreSQL FTS or a lightweight fallback."""
+
+        terms = [part for part in query.split() if part]
+        if not terms or limit <= 0 or offset < 0:
+            return []
+
+        bind = self._session.get_bind()
+        if bind.dialect.name == "postgresql":
+            return self._search_postgres(" ".join(terms), limit=limit, offset=offset)
+        return self._search_fallback(terms, limit=limit, offset=offset)
+
+    def _search_postgres(self, query: str, *, limit: int, offset: int) -> list[B24TranscriptSearchResult]:
+        ts_query = func.websearch_to_tsquery("russian", query)
+        vector = func.to_tsvector("russian", B24Transcript.text_full)
+        rank = func.ts_rank_cd(vector, ts_query)
+        headline = func.ts_headline(
+            "russian",
+            B24Transcript.text_full,
+            ts_query,
+            self._HIGHLIGHT_OPTIONS,
+        )
+
+        statement: Select[tuple[B24Transcript, str, float]] = (
+            select(B24Transcript, headline.label("snippet"), rank.label("score"))
+            .where(vector.op("@@")(ts_query))
+            .order_by(text("score DESC"))
+            .limit(limit)
+            .offset(offset)
+        )
+        rows = self._session.execute(statement).all()
+        results: list[B24TranscriptSearchResult] = []
+        for transcript, snippet, score in rows:
+            results.append(
+                B24TranscriptSearchResult(
+                    transcript=transcript,
+                    snippet=snippet or "",
+                    score=float(score) if score is not None else None,
+                )
+            )
+        return results
+
+    def _search_fallback(
+        self,
+        terms: list[str],
+        *,
+        limit: int,
+        offset: int,
+    ) -> list[B24TranscriptSearchResult]:
+        lowered_terms = [term.casefold() for term in terms]
+        statement: Select[tuple[B24Transcript]] = select(B24Transcript).order_by(
+            B24Transcript.call_record_id
+        )
+        transcripts = self._session.scalars(statement).all()
+        filtered = [t for t in transcripts if _contains_terms(t.text_full, lowered_terms)]
+        sliced = filtered[offset : offset + limit]
+        results: list[B24TranscriptSearchResult] = []
+        for transcript in sliced:
+            snippet = _build_fallback_snippet(transcript.text_full, lowered_terms)
+            results.append(B24TranscriptSearchResult(transcript=transcript, snippet=snippet))
+        return results
+
+
+def _contains_terms(text: str, lowered_terms: list[str]) -> bool:
+    haystack = " ".join(text.split()).casefold()
+    return all(term in haystack for term in lowered_terms)
+
+
+def _build_fallback_snippet(text: str, lowered_terms: list[str], *, context: int = 60) -> str:
+    """Produce a highlighted snippet for non-PostgreSQL databases."""
+
+    compact = " ".join(text.split())
+    lowered = compact.casefold()
+
+    match_index: int | None = None
+    match_length: int = 0
+    for term in lowered_terms:
+        idx = lowered.find(term)
+        if idx == -1:
+            continue
+        if match_index is None or idx < match_index:
+            match_index = idx
+            match_length = len(term)
+    if match_index is None:
+        if len(compact) <= context * 2:
+            return compact
+        return compact[: context * 2].rstrip() + "…"
+
+    start = max(0, match_index - context)
+    end = min(len(compact), match_index + match_length + context)
+    snippet = compact[start:end]
+
+    highlight_start = match_index - start
+    highlight_end = highlight_start + match_length
+    snippet = (
+        snippet[:highlight_start]
+        + "<mark>"
+        + snippet[highlight_start:highlight_end]
+        + "</mark>"
+        + snippet[highlight_end:]
+    )
+
+    if start > 0:
+        snippet = "…" + snippet
+    if end < len(compact):
+        snippet = snippet + "…"
+    return snippet

--- a/tests/test_b24_transcript_search.py
+++ b/tests/test_b24_transcript_search.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from typing import Iterator
+
+import pytest
+from sqlalchemy.orm import Session
+
+from apps.mw.src.db.repositories.transcripts import B24TranscriptRepository
+from tests.transcript_test_utils import make_call_record, transcript_session
+
+
+@pytest.fixture()
+def session() -> Iterator[Session]:
+    with transcript_session() as session:
+        yield session
+
+
+def test_search_returns_snippet_with_highlight(session: Session) -> None:
+    record = make_call_record(session, call_id="CALL-001")
+    repo = B24TranscriptRepository(session)
+    repo.create(
+        call_record_id=record.id,
+        text_full="Менеджер оформляет возврат телефона и уточняет условия оплаты клиента.",
+    )
+
+    other = make_call_record(session, call_id="CALL-002")
+    repo.create(
+        call_record_id=other.id,
+        text_full="Курьер согласовывает время доставки аксессуаров.",
+    )
+
+    results = repo.search("возврат", limit=5)
+    assert len(results) == 1
+    match = results[0]
+    assert match.transcript.call_record_id == record.id
+    assert "<mark>возврат</mark>" in match.snippet.lower()
+    assert match.snippet.startswith("Менеджер")
+
+
+def test_search_honors_limit_and_offset(session: Session) -> None:
+    repo = B24TranscriptRepository(session)
+    first = make_call_record(session, call_id="CALL-010")
+    repo.create(
+        call_record_id=first.id,
+        text_full="Клиент уточняет статус возврата и запрашивает курьера.",
+    )
+    second = make_call_record(session, call_id="CALL-011")
+    repo.create(
+        call_record_id=second.id,
+        text_full="Супервайзер передаёт клиенту информацию и подтверждает возврат.",
+    )
+    third = make_call_record(session, call_id="CALL-012")
+    repo.create(
+        call_record_id=third.id,
+        text_full="Менеджер приветствует клиента и обсуждает ремонт устройства.",
+    )
+
+    page_one = repo.search("клиент", limit=1)
+    assert len(page_one) == 1
+    assert page_one[0].transcript.call_record_id == first.id
+
+    page_two = repo.search("клиент", limit=1, offset=1)
+    assert len(page_two) == 1
+    assert page_two[0].transcript.call_record_id == second.id
+
+
+def test_search_returns_empty_for_blank_query(session: Session) -> None:
+    repo = B24TranscriptRepository(session)
+    assert repo.search("   ") == []
+    assert repo.search("", limit=5) == []
+    assert repo.search("клиент", limit=0) == []

--- a/tests/test_db_transcript_repository.py
+++ b/tests/test_db_transcript_repository.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from typing import Iterator
+
+import pytest
+from sqlalchemy.orm import Session
+
+from apps.mw.src.db.repositories.transcripts import B24TranscriptRepository
+from tests.transcript_test_utils import make_call_record, transcript_session
+
+
+@pytest.fixture()
+def session() -> Iterator[Session]:
+    with transcript_session() as session:
+        yield session
+
+
+def test_create_transcript_persists_and_links(session: Session) -> None:
+    record = make_call_record(session)
+    repo = B24TranscriptRepository(session)
+
+    transcript = repo.create(
+        call_record_id=record.id,
+        text_full="Менеджер общается с клиентом о возврате устройства.",
+        text_normalized="менеджер общается с клиентом о возврате устройства",
+        metadata={"segments": []},
+    )
+
+    session.refresh(record)
+    assert transcript.id is not None
+    assert record.transcript is transcript
+    assert transcript.metadata_json == {"segments": []}
+
+
+def test_get_by_call_record_id_returns_none_when_absent(session: Session) -> None:
+    repo = B24TranscriptRepository(session)
+    assert repo.get_by_call_record_id(9999) is None
+
+
+def test_get_by_call_record_id_returns_existing_transcript(session: Session) -> None:
+    record = make_call_record(session)
+    repo = B24TranscriptRepository(session)
+    repo.create(call_record_id=record.id, text_full="Добрый день", metadata=None)
+
+    found = repo.get_by_call_record_id(record.id)
+    assert found is not None
+    assert found.call_record_id == record.id
+
+
+def test_update_transcript_changes_fields(session: Session) -> None:
+    record = make_call_record(session)
+    repo = B24TranscriptRepository(session)
+    transcript = repo.create(
+        call_record_id=record.id,
+        text_full="Начальная версия",
+        text_normalized="начальная версия",
+        metadata={"segments": ["intro"]},
+    )
+
+    updated = repo.update(
+        transcript,
+        text_full="Обновлённая версия стенограммы",
+        text_normalized="обновленная версия стенограммы",
+        metadata={"segments": ["intro", "resolution"]},
+    )
+
+    assert updated.text_full.startswith("Обновлённая")
+    assert updated.text_normalized.endswith("стенограммы")
+    assert updated.metadata_json == {"segments": ["intro", "resolution"]}
+
+
+def test_delete_transcript_removes_relationship(session: Session) -> None:
+    record = make_call_record(session)
+    repo = B24TranscriptRepository(session)
+    transcript = repo.create(call_record_id=record.id, text_full="Удаляемая стенограмма")
+
+    repo.delete(transcript)
+    session.expire(record, ["transcript"])
+
+    assert record.transcript is None
+    assert repo.get_by_call_record_id(record.id) is None

--- a/tests/transcript_test_utils.py
+++ b/tests/transcript_test_utils.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from typing import Iterator
+from uuid import uuid4
+
+from sqlalchemy import Column, String, Table, create_engine, text
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from apps.mw.src.db import Base
+from apps.mw.src.db.models import (
+    B24Transcript,
+    CallDirection,
+    CallExport,
+    CallExportStatus,
+    CallRecord,
+    CallRecordStatus,
+)
+
+
+@contextmanager
+def transcript_session() -> Iterator[Session]:
+    """Provide an in-memory SQLite session with transcript tables."""
+
+    engine = _build_engine()
+    SessionLocal = sessionmaker(bind=engine, future=True)
+    try:
+        with SessionLocal() as session:
+            yield session
+    finally:
+        engine.dispose()
+
+
+def _build_engine() -> Engine:
+    engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+    if "core.users" not in Base.metadata.tables:
+        Table(
+            "users",
+            Base.metadata,
+            Column("user_id", String, primary_key=True),
+            schema="core",
+            extend_existing=True,
+        )
+    with engine.begin() as connection:
+        connection.execute(text('CREATE TABLE IF NOT EXISTS "core.users" (user_id TEXT PRIMARY KEY)'))
+    Base.metadata.create_all(
+        engine,
+        tables=[CallExport.__table__, CallRecord.__table__, B24Transcript.__table__],
+    )
+    return engine
+
+
+def make_call_record(session: Session, call_id: str = "CALL-001") -> CallRecord:
+    """Insert a call export and associated record for testing."""
+
+    export = CallExport(
+        run_id=uuid4(),
+        period_from=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        period_to=datetime(2024, 1, 2, tzinfo=timezone.utc),
+        status=CallExportStatus.PENDING,
+    )
+    record = CallRecord(
+        export=export,
+        call_id=call_id,
+        record_id=f"{call_id}-rec",
+        call_started_at=datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc),
+        direction=CallDirection.INBOUND,
+        from_number="+79990000001",
+        to_number="+79990000002",
+        duration_sec=180,
+        recording_url=f"https://example.com/records/{call_id}.mp3",
+        status=CallRecordStatus.COMPLETED,
+    )
+    session.add_all([export, record])
+    session.commit()
+    session.refresh(record)
+    return record


### PR DESCRIPTION
## Summary
- add the B24Transcript ORM model linked to call records
- create an Alembic migration with the transcript table and Russian FTS index
- implement repository CRUD/search helpers with unit and integration tests

## Testing
- PYTHONPATH=. pytest tests/test_db_transcript_repository.py tests/test_b24_transcript_search.py

------
https://chatgpt.com/codex/tasks/task_e_68d8fc57f0a8832ab387d723c9442ede