### PR TITLE
feat: enable PII masking by default in non-local envs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -61,6 +61,9 @@ CORS_ORIGINS=http://localhost:3000
 MAX_PAGE_SIZE=100
 REQUEST_TIMEOUT_S=30
 ENABLE_TRACING=false
-PII_MASKING_ENABLED=false
+# По умолчанию (если переменная не задана) для APP_ENV, отличного от "local",
+# маскирование включается автоматически. Раскомментируйте и установите в false,
+# чтобы принудительно отключить его в нужной среде.
+# PII_MASKING_ENABLED=false
 DISK_ENCRYPTION_FLAG=false
 CALL_SUMMARY_ENABLED=false


### PR DESCRIPTION
## Summary
- enable automatic PII masking when `APP_ENV` is non-local via the settings validator
- cover the new default with a regression test in `tests/test_observability_logging.py`
- document the default and opt-out guidance in `.env.example`

## Testing
- `PYTHONPATH=. pytest tests/test_observability_logging.py`


------
https://chatgpt.com/codex/tasks/task_e_68d95e049c60832ab02957c35d7ce130