### PR TITLE
feat: add delivery domain models and repositories

### DIFF
--- a/apps/mw/migrations/versions/0008_delivery_tables.py
+++ b/apps/mw/migrations/versions/0008_delivery_tables.py
@@ -1,0 +1,286 @@
+"""Create delivery tables for couriers and orders."""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "0008_delivery_tables"
+down_revision = "0007_b24_transcripts"
+branch_labels = None
+depends_on = None
+
+
+COURIER_STATUS_CHECK = (
+    "status IN ('onboarding','active','suspended','inactive')"
+)
+
+DELIVERY_ORDER_STATUS_CHECK = (
+    "status IN ('new','picking','ready','picked_up','on_route','delivered','cash_returned','done','failed','refused','cancelled')"
+)
+
+DELIVERY_ASSIGNMENT_STATUS_CHECK = (
+    "status IN ('pending','accepted','declined','in_progress','completed','cancelled')"
+)
+
+DELIVERY_LOG_STATUS_CHECK = (
+    "status IN ('info','success','warning','error')"
+)
+
+
+def upgrade() -> None:
+    op.create_table(
+        "couriers",
+        sa.Column(
+            "courier_id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+        ),
+        sa.Column("external_id", sa.Text(), nullable=True),
+        sa.Column("full_name", sa.Text(), nullable=False),
+        sa.Column("phone", sa.Text(), nullable=False),
+        sa.Column("email", sa.Text(), nullable=True),
+        sa.Column("status", sa.Text(), nullable=False, server_default="onboarding"),
+        sa.Column(
+            "metadata_json",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=True,
+        ),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.CheckConstraint(COURIER_STATUS_CHECK, name="chk_couriers_status"),
+        sa.CheckConstraint(
+            "length(trim(phone)) > 0", name="chk_couriers_phone_not_blank"
+        ),
+    )
+
+    op.create_index("idx_couriers_status", "couriers", ["status"])
+
+    op.create_table(
+        "delivery_orders",
+        sa.Column(
+            "order_id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+        ),
+        sa.Column("external_id", sa.Text(), nullable=True),
+        sa.Column("status", sa.Text(), nullable=False, server_default="new"),
+        sa.Column("courier_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column(
+            "delivery_price",
+            sa.Numeric(12, 2),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        sa.Column(
+            "cod_amount",
+            sa.Numeric(12, 2),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        sa.Column(
+            "currency_code",
+            sa.String(length=3),
+            nullable=False,
+            server_default=sa.text("'RUB'"),
+        ),
+        sa.Column("expected_delivery_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("delivered_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column(
+            "metadata_json",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=True,
+        ),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.ForeignKeyConstraint(
+            ["courier_id"], ["couriers.courier_id"], ondelete="SET NULL"
+        ),
+        sa.CheckConstraint(
+            DELIVERY_ORDER_STATUS_CHECK, name="chk_delivery_orders_status"
+        ),
+        sa.CheckConstraint(
+            "delivery_price >= 0",
+            name="chk_delivery_orders_delivery_price_non_negative",
+        ),
+        sa.CheckConstraint(
+            "cod_amount >= 0",
+            name="chk_delivery_orders_cod_amount_non_negative",
+        ),
+    )
+
+    op.create_index(
+        "idx_delivery_orders_status_active",
+        "delivery_orders",
+        ["status"],
+        postgresql_where=sa.text(
+            "status IN ('new','picking','ready','picked_up','on_route','delivered')"
+        ),
+    )
+    op.create_index(
+        "idx_delivery_orders_courier_status",
+        "delivery_orders",
+        ["courier_id", "status"],
+    )
+    op.create_index(
+        "uq_delivery_orders_external_id",
+        "delivery_orders",
+        ["external_id"],
+        unique=True,
+        postgresql_where=sa.text("external_id IS NOT NULL"),
+    )
+
+    op.create_table(
+        "delivery_assignments",
+        sa.Column(
+            "assignment_id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+        ),
+        sa.Column("order_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("courier_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column(
+            "status", sa.Text(), nullable=False, server_default="pending"
+        ),
+        sa.Column("notes", sa.Text(), nullable=True),
+        sa.Column(
+            "assigned_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column("accepted_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("completed_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.ForeignKeyConstraint(
+            ["order_id"], ["delivery_orders.order_id"], ondelete="CASCADE"
+        ),
+        sa.ForeignKeyConstraint(
+            ["courier_id"], ["couriers.courier_id"], ondelete="RESTRICT"
+        ),
+        sa.CheckConstraint(
+            DELIVERY_ASSIGNMENT_STATUS_CHECK,
+            name="chk_delivery_assignments_status",
+        ),
+    )
+
+    op.create_index(
+        "idx_delivery_assignments_order_status",
+        "delivery_assignments",
+        ["order_id", "status"],
+    )
+    op.create_index(
+        "uq_delivery_assignments_active",
+        "delivery_assignments",
+        ["order_id", "courier_id"],
+        unique=True,
+        postgresql_where=sa.text(
+            "status IN ('pending','accepted','in_progress')"
+        ),
+    )
+
+    op.create_table(
+        "delivery_logs",
+        sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
+        sa.Column("order_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("assignment_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("courier_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("status", sa.Text(), nullable=False, server_default="info"),
+        sa.Column("event_type", sa.Text(), nullable=False),
+        sa.Column("message", sa.Text(), nullable=True),
+        sa.Column(
+            "payload",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=True,
+        ),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.ForeignKeyConstraint(
+            ["order_id"], ["delivery_orders.order_id"], ondelete="CASCADE"
+        ),
+        sa.ForeignKeyConstraint(
+            ["assignment_id"], ["delivery_assignments.assignment_id"], ondelete="SET NULL"
+        ),
+        sa.ForeignKeyConstraint(
+            ["courier_id"], ["couriers.courier_id"], ondelete="SET NULL"
+        ),
+        sa.CheckConstraint(
+            DELIVERY_LOG_STATUS_CHECK,
+            name="chk_delivery_logs_status",
+        ),
+    )
+
+    op.create_index(
+        "idx_delivery_logs_order_created",
+        "delivery_logs",
+        ["order_id", "created_at"],
+    )
+    op.create_index("idx_delivery_logs_status", "delivery_logs", ["status"])
+
+
+def downgrade() -> None:
+    op.drop_index("idx_delivery_logs_status", table_name="delivery_logs")
+    op.drop_index(
+        "idx_delivery_logs_order_created", table_name="delivery_logs"
+    )
+    op.drop_table("delivery_logs")
+
+    op.drop_index(
+        "uq_delivery_assignments_active", table_name="delivery_assignments"
+    )
+    op.drop_index(
+        "idx_delivery_assignments_order_status",
+        table_name="delivery_assignments",
+    )
+    op.drop_table("delivery_assignments")
+
+    op.drop_index(
+        "uq_delivery_orders_external_id", table_name="delivery_orders"
+    )
+    op.drop_index(
+        "idx_delivery_orders_courier_status", table_name="delivery_orders"
+    )
+    op.drop_index(
+        "idx_delivery_orders_status_active", table_name="delivery_orders"
+    )
+    op.drop_table("delivery_orders")
+
+    op.drop_index("idx_couriers_status", table_name="couriers")
+    op.drop_table("couriers")

--- a/apps/mw/src/db/__init__.py
+++ b/apps/mw/src/db/__init__.py
@@ -1,5 +1,23 @@
 """Database models exposed for seed scripts and tests."""
 
-from .models import Base, IntegrationLog, Return, ReturnLine
+from .models import (
+    Base,
+    Courier,
+    DeliveryAssignment,
+    DeliveryLog,
+    DeliveryOrder,
+    IntegrationLog,
+    Return,
+    ReturnLine,
+)
 
-__all__ = ["Base", "IntegrationLog", "Return", "ReturnLine"]
+__all__ = [
+    "Base",
+    "Courier",
+    "DeliveryAssignment",
+    "DeliveryLog",
+    "DeliveryOrder",
+    "IntegrationLog",
+    "Return",
+    "ReturnLine",
+]

--- a/apps/mw/src/db/models.py
+++ b/apps/mw/src/db/models.py
@@ -111,6 +111,51 @@ class CallDirection(str, Enum):
     INTERNAL = "internal"
 
 
+class CourierStatus(str, Enum):
+    """Lifecycle states of a courier in the Walking Warehouse."""
+
+    ONBOARDING = "onboarding"
+    ACTIVE = "active"
+    SUSPENDED = "suspended"
+    INACTIVE = "inactive"
+
+
+class DeliveryOrderStatus(str, Enum):
+    """Workflow statuses for the delivery order lifecycle."""
+
+    NEW = "new"
+    PICKING = "picking"
+    READY = "ready"
+    PICKED_UP = "picked_up"
+    ON_ROUTE = "on_route"
+    DELIVERED = "delivered"
+    CASH_RETURNED = "cash_returned"
+    DONE = "done"
+    FAILED = "failed"
+    REFUSED = "refused"
+    CANCELLED = "cancelled"
+
+
+class DeliveryAssignmentStatus(str, Enum):
+    """Workflow states for the courier task assignment."""
+
+    PENDING = "pending"
+    ACCEPTED = "accepted"
+    DECLINED = "declined"
+    IN_PROGRESS = "in_progress"
+    COMPLETED = "completed"
+    CANCELLED = "cancelled"
+
+
+class DeliveryLogStatus(str, Enum):
+    """High level result of a delivery workflow event."""
+
+    INFO = "info"
+    SUCCESS = "success"
+    WARNING = "warning"
+    ERROR = "error"
+
+
 JSONBType = JSONB().with_variant(SQLiteJSON(), "sqlite")
 
 
@@ -518,3 +563,312 @@ class B24Transcript(Base):
     )
 
     call_record: Mapped[CallRecord] = relationship(back_populates="transcript")
+
+
+class Courier(Base):
+    """Courier reference stored in the Walking Warehouse schema."""
+
+    __tablename__ = "couriers"
+    __table_args__ = (
+        CheckConstraint(
+            "status IN ('onboarding','active','suspended','inactive')",
+            name="chk_couriers_status",
+        ),
+        CheckConstraint(
+            "length(trim(phone)) > 0",
+            name="chk_couriers_phone_not_blank",
+        ),
+        Index("idx_couriers_status", "status"),
+    )
+
+    courier_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        primary_key=True,
+        default=uuid4,
+    )
+    external_id: Mapped[str | None] = mapped_column(Text, nullable=True)
+    full_name: Mapped[str] = mapped_column(Text, nullable=False)
+    phone: Mapped[str] = mapped_column(Text, nullable=False)
+    email: Mapped[str | None] = mapped_column(Text, nullable=True)
+    status: Mapped[CourierStatus] = mapped_column(
+        _enum_type(CourierStatus, name="courier_status", length=16),
+        nullable=False,
+        default=CourierStatus.ONBOARDING,
+        server_default=CourierStatus.ONBOARDING.value,
+    )
+    metadata_json: Mapped[dict[str, Any] | None] = mapped_column(
+        JSONBType,
+        nullable=True,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+    orders: Mapped[list["DeliveryOrder"]] = relationship(
+        back_populates="courier",
+        cascade="all, delete-orphan",
+    )
+    assignments: Mapped[list["DeliveryAssignment"]] = relationship(
+        back_populates="courier",
+        cascade="all, delete-orphan",
+    )
+    logs: Mapped[list["DeliveryLog"]] = relationship(back_populates="courier")
+
+
+class DeliveryOrder(Base):
+    """Delivery order orchestrated by the middleware."""
+
+    __tablename__ = "delivery_orders"
+    __table_args__ = (
+        CheckConstraint(
+            "status IN ('new','picking','ready','picked_up','on_route','delivered','cash_returned','done','failed','refused','cancelled')",
+            name="chk_delivery_orders_status",
+        ),
+        CheckConstraint(
+            "delivery_price >= 0",
+            name="chk_delivery_orders_delivery_price_non_negative",
+        ),
+        CheckConstraint(
+            "cod_amount >= 0",
+            name="chk_delivery_orders_cod_amount_non_negative",
+        ),
+        Index(
+            "idx_delivery_orders_status_active",
+            "status",
+            postgresql_where=text(
+                "status IN ('new','picking','ready','picked_up','on_route','delivered')"
+            ),
+            sqlite_where=text(
+                "status IN ('new','picking','ready','picked_up','on_route','delivered')"
+            ),
+        ),
+        Index("idx_delivery_orders_courier_status", "courier_id", "status"),
+        Index(
+            "uq_delivery_orders_external_id",
+            "external_id",
+            unique=True,
+            postgresql_where=text("external_id IS NOT NULL"),
+            sqlite_where=text("external_id IS NOT NULL"),
+        ),
+    )
+
+    order_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        primary_key=True,
+        default=uuid4,
+    )
+    external_id: Mapped[str | None] = mapped_column(Text, nullable=True)
+    status: Mapped[DeliveryOrderStatus] = mapped_column(
+        _enum_type(DeliveryOrderStatus, name="delivery_order_status", length=32),
+        nullable=False,
+        default=DeliveryOrderStatus.NEW,
+        server_default=DeliveryOrderStatus.NEW.value,
+    )
+    courier_id: Mapped[UUID | None] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("couriers.courier_id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    delivery_price: Mapped[Decimal] = mapped_column(
+        Numeric(12, 2),
+        nullable=False,
+        default=Decimal("0"),
+        server_default=text("0"),
+    )
+    cod_amount: Mapped[Decimal] = mapped_column(
+        Numeric(12, 2),
+        nullable=False,
+        default=Decimal("0"),
+        server_default=text("0"),
+    )
+    currency_code: Mapped[str] = mapped_column(
+        String(3),
+        nullable=False,
+        default="RUB",
+        server_default=text("'RUB'"),
+    )
+    expected_delivery_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+    )
+    delivered_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+    )
+    metadata_json: Mapped[dict[str, Any] | None] = mapped_column(
+        JSONBType,
+        nullable=True,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+    courier: Mapped[Courier | None] = relationship(
+        back_populates="orders",
+        lazy="joined",
+    )
+    assignments: Mapped[list["DeliveryAssignment"]] = relationship(
+        back_populates="order",
+        cascade="all, delete-orphan",
+    )
+    logs: Mapped[list["DeliveryLog"]] = relationship(
+        back_populates="order",
+        cascade="all, delete-orphan",
+    )
+
+
+class DeliveryAssignment(Base):
+    """Link between a courier and delivery order with status tracking."""
+
+    __tablename__ = "delivery_assignments"
+    __table_args__ = (
+        CheckConstraint(
+            "status IN ('pending','accepted','declined','in_progress','completed','cancelled')",
+            name="chk_delivery_assignments_status",
+        ),
+        Index("idx_delivery_assignments_order_status", "order_id", "status"),
+        Index(
+            "uq_delivery_assignments_active",
+            "order_id",
+            "courier_id",
+            unique=True,
+            postgresql_where=text(
+                "status IN ('pending','accepted','in_progress')"
+            ),
+            sqlite_where=text(
+                "status IN ('pending','accepted','in_progress')"
+            ),
+        ),
+    )
+
+    assignment_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        primary_key=True,
+        default=uuid4,
+    )
+    order_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("delivery_orders.order_id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    courier_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("couriers.courier_id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+    status: Mapped[DeliveryAssignmentStatus] = mapped_column(
+        _enum_type(
+            DeliveryAssignmentStatus,
+            name="delivery_assignment_status",
+            length=32,
+        ),
+        nullable=False,
+        default=DeliveryAssignmentStatus.PENDING,
+        server_default=DeliveryAssignmentStatus.PENDING.value,
+    )
+    notes: Mapped[str | None] = mapped_column(Text, nullable=True)
+    assigned_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+    accepted_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+    )
+    completed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+    order: Mapped[DeliveryOrder] = relationship(back_populates="assignments")
+    courier: Mapped[Courier] = relationship(back_populates="assignments")
+    logs: Mapped[list["DeliveryLog"]] = relationship(
+        back_populates="assignment",
+        cascade="all, delete-orphan",
+    )
+
+
+class DeliveryLog(Base):
+    """Auditable log entry for a delivery order or assignment event."""
+
+    __tablename__ = "delivery_logs"
+    __table_args__ = (
+        CheckConstraint(
+            "status IN ('info','success','warning','error')",
+            name="chk_delivery_logs_status",
+        ),
+        Index("idx_delivery_logs_order_created", "order_id", "created_at"),
+        Index("idx_delivery_logs_status", "status"),
+    )
+
+    id: Mapped[int] = mapped_column(
+        BigInteger().with_variant(Integer, "sqlite"),
+        primary_key=True,
+        autoincrement=True,
+    )
+    order_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("delivery_orders.order_id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    assignment_id: Mapped[UUID | None] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("delivery_assignments.assignment_id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    courier_id: Mapped[UUID | None] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("couriers.courier_id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    status: Mapped[DeliveryLogStatus] = mapped_column(
+        _enum_type(DeliveryLogStatus, name="delivery_log_status", length=16),
+        nullable=False,
+        default=DeliveryLogStatus.INFO,
+        server_default=DeliveryLogStatus.INFO.value,
+    )
+    event_type: Mapped[str] = mapped_column(Text, nullable=False)
+    message: Mapped[str | None] = mapped_column(Text, nullable=True)
+    payload: Mapped[dict[str, Any] | None] = mapped_column(
+        JSONBType,
+        nullable=True,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+
+    order: Mapped[DeliveryOrder] = relationship(back_populates="logs")
+    assignment: Mapped[DeliveryAssignment | None] = relationship(
+        back_populates="logs"
+    )
+    courier: Mapped[Courier | None] = relationship(back_populates="logs")

--- a/apps/mw/src/db/repositories/__init__.py
+++ b/apps/mw/src/db/repositories/__init__.py
@@ -1,5 +1,16 @@
 """Repository helpers for database access patterns."""
 
+from .couriers import CourierRepository
+from .delivery_assignments import DeliveryAssignmentRepository
+from .delivery_logs import DeliveryLogRepository
+from .delivery_orders import DeliveryOrderRepository
 from .transcripts import B24TranscriptRepository, B24TranscriptSearchResult
 
-__all__ = ["B24TranscriptRepository", "B24TranscriptSearchResult"]
+__all__ = [
+    "B24TranscriptRepository",
+    "B24TranscriptSearchResult",
+    "CourierRepository",
+    "DeliveryAssignmentRepository",
+    "DeliveryLogRepository",
+    "DeliveryOrderRepository",
+]

--- a/apps/mw/src/db/repositories/couriers.py
+++ b/apps/mw/src/db/repositories/couriers.py
@@ -1,0 +1,88 @@
+"""Repository helpers for :class:`~apps.mw.src.db.models.Courier`."""
+
+from __future__ import annotations
+
+from typing import Iterable
+from uuid import UUID
+
+from sqlalchemy import Select, select
+from sqlalchemy.orm import Session
+
+from apps.mw.src.db.models import Courier, CourierStatus
+
+
+class CourierRepository:
+    """CRUD facade around the :class:`Courier` ORM model."""
+
+    def __init__(self, session: Session) -> None:
+        self._session = session
+
+    def create(
+        self,
+        *,
+        external_id: str | None,
+        full_name: str,
+        phone: str,
+        email: str | None = None,
+        status: CourierStatus = CourierStatus.ONBOARDING,
+        metadata: dict[str, object] | None = None,
+    ) -> Courier:
+        courier = Courier(
+            external_id=external_id,
+            full_name=full_name,
+            phone=phone,
+            email=email,
+            status=status,
+            metadata_json=metadata,
+        )
+        self._session.add(courier)
+        self._session.flush()
+        return courier
+
+    def get(self, courier_id: UUID) -> Courier | None:
+        statement: Select[tuple[Courier]] = select(Courier).where(
+            Courier.courier_id == courier_id
+        )
+        return self._session.scalar(statement)
+
+    def list_by_status(self, *statuses: CourierStatus) -> list[Courier]:
+        if not statuses:
+            statement: Select[tuple[Courier]] = select(Courier).order_by(
+                Courier.full_name
+            )
+        else:
+            statement = select(Courier).where(Courier.status.in_(statuses)).order_by(
+                Courier.full_name
+            )
+        return list(self._session.scalars(statement).all())
+
+    def update_status(self, courier: Courier, status: CourierStatus) -> Courier:
+        courier.status = status
+        self._session.flush()
+        return courier
+
+    def update_contacts(
+        self,
+        courier: Courier,
+        *,
+        phone: str | None = None,
+        email: str | None = None,
+        metadata: dict[str, object] | None = None,
+    ) -> Courier:
+        if phone is not None:
+            courier.phone = phone
+        if email is not None:
+            courier.email = email
+        if metadata is not None:
+            courier.metadata_json = metadata
+        self._session.flush()
+        return courier
+
+    def delete(self, courier: Courier) -> None:
+        self._session.delete(courier)
+        self._session.flush()
+
+    def upsert_many(self, couriers: Iterable[Courier]) -> None:
+        for courier in couriers:
+            self._session.merge(courier)
+        self._session.flush()

--- a/apps/mw/src/db/repositories/delivery_assignments.py
+++ b/apps/mw/src/db/repositories/delivery_assignments.py
@@ -1,0 +1,95 @@
+"""Repository helpers for :class:`DeliveryAssignment`."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from sqlalchemy import Select, select
+from sqlalchemy.orm import Session
+
+from apps.mw.src.db.models import (
+    DeliveryAssignment,
+    DeliveryAssignmentStatus,
+)
+
+
+class DeliveryAssignmentRepository:
+    """CRUD helpers for delivery assignments."""
+
+    def __init__(self, session: Session) -> None:
+        self._session = session
+
+    def create(
+        self,
+        *,
+        order_id: UUID,
+        courier_id: UUID,
+        status: DeliveryAssignmentStatus = DeliveryAssignmentStatus.PENDING,
+        notes: str | None = None,
+    ) -> DeliveryAssignment:
+        assignment = DeliveryAssignment(
+            order_id=order_id,
+            courier_id=courier_id,
+            status=status,
+            notes=notes,
+        )
+        self._session.add(assignment)
+        self._session.flush()
+        return assignment
+
+    def get(self, assignment_id: UUID) -> DeliveryAssignment | None:
+        statement: Select[tuple[DeliveryAssignment]] = select(
+            DeliveryAssignment
+        ).where(DeliveryAssignment.assignment_id == assignment_id)
+        return self._session.scalar(statement)
+
+    def list_active_for_order(self, order_id: UUID) -> list[DeliveryAssignment]:
+        statement = (
+            select(DeliveryAssignment)
+            .where(
+                DeliveryAssignment.order_id == order_id,
+                DeliveryAssignment.status.in_(
+                    [
+                        DeliveryAssignmentStatus.PENDING,
+                        DeliveryAssignmentStatus.ACCEPTED,
+                        DeliveryAssignmentStatus.IN_PROGRESS,
+                    ]
+                ),
+            )
+            .order_by(DeliveryAssignment.assigned_at)
+        )
+        return list(self._session.scalars(statement).all())
+
+    def update_status(
+        self,
+        assignment: DeliveryAssignment,
+        status: DeliveryAssignmentStatus,
+        *,
+        accepted_at: datetime | None = None,
+        completed_at: datetime | None = None,
+    ) -> DeliveryAssignment:
+        assignment.status = status
+        if accepted_at is not None:
+            assignment.accepted_at = accepted_at
+        if completed_at is not None:
+            assignment.completed_at = completed_at
+        self._session.flush()
+        return assignment
+
+    def reassign(
+        self,
+        assignment: DeliveryAssignment,
+        *,
+        courier_id: UUID,
+        notes: str | None = None,
+    ) -> DeliveryAssignment:
+        assignment.courier_id = courier_id
+        if notes is not None:
+            assignment.notes = notes
+        self._session.flush()
+        return assignment
+
+    def delete(self, assignment: DeliveryAssignment) -> None:
+        self._session.delete(assignment)
+        self._session.flush()

--- a/apps/mw/src/db/repositories/delivery_logs.py
+++ b/apps/mw/src/db/repositories/delivery_logs.py
@@ -1,0 +1,53 @@
+"""Repository helpers for :class:`DeliveryLog`."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy import Select, select
+from sqlalchemy.orm import Session
+
+from apps.mw.src.db.models import DeliveryLog, DeliveryLogStatus
+
+
+class DeliveryLogRepository:
+    """CRUD helpers for delivery workflow logs."""
+
+    def __init__(self, session: Session) -> None:
+        self._session = session
+
+    def create(
+        self,
+        *,
+        order_id: UUID,
+        status: DeliveryLogStatus,
+        event_type: str,
+        assignment_id: UUID | None = None,
+        courier_id: UUID | None = None,
+        message: str | None = None,
+        payload: dict[str, object] | None = None,
+    ) -> DeliveryLog:
+        log_entry = DeliveryLog(
+            order_id=order_id,
+            assignment_id=assignment_id,
+            courier_id=courier_id,
+            status=status,
+            event_type=event_type,
+            message=message,
+            payload=payload,
+        )
+        self._session.add(log_entry)
+        self._session.flush()
+        return log_entry
+
+    def list_for_order(self, order_id: UUID) -> list[DeliveryLog]:
+        statement: Select[tuple[DeliveryLog]] = (
+            select(DeliveryLog)
+            .where(DeliveryLog.order_id == order_id)
+            .order_by(DeliveryLog.created_at)
+        )
+        return list(self._session.scalars(statement).all())
+
+    def delete(self, log_entry: DeliveryLog) -> None:
+        self._session.delete(log_entry)
+        self._session.flush()

--- a/apps/mw/src/db/repositories/delivery_orders.py
+++ b/apps/mw/src/db/repositories/delivery_orders.py
@@ -1,0 +1,116 @@
+"""Repository helpers for delivery orders and assignments."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+from uuid import UUID
+
+from sqlalchemy import Select, select
+from sqlalchemy.orm import Session
+
+from apps.mw.src.db.models import DeliveryOrder, DeliveryOrderStatus
+
+
+class DeliveryOrderRepository:
+    """CRUD facade around :class:`DeliveryOrder`."""
+
+    def __init__(self, session: Session) -> None:
+        self._session = session
+
+    def create(
+        self,
+        *,
+        external_id: str | None,
+        status: DeliveryOrderStatus = DeliveryOrderStatus.NEW,
+        courier_id: UUID | None = None,
+        delivery_price: Decimal | None = None,
+        cod_amount: Decimal | None = None,
+        currency_code: str = "RUB",
+        expected_delivery_at: datetime | None = None,
+        metadata: dict[str, object] | None = None,
+    ) -> DeliveryOrder:
+        order = DeliveryOrder(
+            external_id=external_id,
+            status=status,
+            courier_id=courier_id,
+            delivery_price=delivery_price or Decimal("0"),
+            cod_amount=cod_amount or Decimal("0"),
+            currency_code=currency_code,
+            expected_delivery_at=expected_delivery_at,
+            metadata_json=metadata,
+        )
+        self._session.add(order)
+        self._session.flush()
+        return order
+
+    def get(self, order_id: UUID) -> DeliveryOrder | None:
+        statement: Select[tuple[DeliveryOrder]] = select(DeliveryOrder).where(
+            DeliveryOrder.order_id == order_id
+        )
+        return self._session.scalar(statement)
+
+    def get_by_external_id(self, external_id: str) -> DeliveryOrder | None:
+        statement: Select[tuple[DeliveryOrder]] = select(DeliveryOrder).where(
+            DeliveryOrder.external_id == external_id
+        )
+        return self._session.scalar(statement)
+
+    def list_active_for_courier(
+        self, courier_id: UUID
+    ) -> list[DeliveryOrder]:
+        statement = (
+            select(DeliveryOrder)
+            .where(
+                DeliveryOrder.courier_id == courier_id,
+                DeliveryOrder.status.in_(
+                    [
+                        DeliveryOrderStatus.NEW,
+                        DeliveryOrderStatus.PICKING,
+                        DeliveryOrderStatus.READY,
+                        DeliveryOrderStatus.PICKED_UP,
+                        DeliveryOrderStatus.ON_ROUTE,
+                    ]
+                ),
+            )
+            .order_by(DeliveryOrder.created_at)
+        )
+        return list(self._session.scalars(statement).all())
+
+    def update_status(
+        self,
+        order: DeliveryOrder,
+        status: DeliveryOrderStatus,
+        *,
+        delivered_at: datetime | None = None,
+    ) -> DeliveryOrder:
+        order.status = status
+        if delivered_at is not None:
+            order.delivered_at = delivered_at
+        self._session.flush()
+        return order
+
+    def assign_courier(
+        self, order: DeliveryOrder, *, courier_id: UUID | None
+    ) -> DeliveryOrder:
+        order.courier_id = courier_id
+        self._session.flush()
+        return order
+
+    def update_amounts(
+        self,
+        order: DeliveryOrder,
+        *,
+        delivery_price: Decimal | None = None,
+        cod_amount: Decimal | None = None,
+    ) -> DeliveryOrder:
+        if delivery_price is not None:
+            order.delivery_price = delivery_price
+        if cod_amount is not None:
+            order.cod_amount = cod_amount
+        self._session.flush()
+        return order
+
+    def delete(self, order: DeliveryOrder) -> None:
+        self._session.delete(order)
+        self._session.flush()

--- a/tests/test_db_models_delivery.py
+++ b/tests/test_db_models_delivery.py
@@ -1,0 +1,123 @@
+"""Integration tests for delivery-related ORM mappings."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import create_engine, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from apps.mw.src.db.models import (
+    Base,
+    Courier,
+    CourierStatus,
+    DeliveryAssignment,
+    DeliveryAssignmentStatus,
+    DeliveryLog,
+    DeliveryLogStatus,
+    DeliveryOrder,
+    DeliveryOrderStatus,
+)
+
+
+def _create_all(engine) -> None:
+    Base.metadata.create_all(
+        engine,
+        tables=[
+            Courier.__table__,
+            DeliveryOrder.__table__,
+            DeliveryAssignment.__table__,
+            DeliveryLog.__table__,
+        ],
+    )
+
+
+def test_delivery_order_relationships_roundtrip() -> None:
+    """Ensure courier/order/assignment/log relations work end-to-end."""
+
+    engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+    _create_all(engine)
+
+    courier_id = uuid4()
+
+    with Session(engine) as session:
+        courier = Courier(
+            courier_id=courier_id,
+            external_id="courier-ext-1",
+            full_name="Иван Курьер",
+            phone="+79991234567",
+            status=CourierStatus.ACTIVE,
+        )
+        order = DeliveryOrder(
+            courier=courier,
+            external_id="ORD-1C-123",
+            status=DeliveryOrderStatus.READY,
+            delivery_price=Decimal("150.50"),
+            cod_amount=Decimal("500.00"),
+            currency_code="RUB",
+            expected_delivery_at=datetime(2024, 4, 1, tzinfo=timezone.utc),
+        )
+        assignment = DeliveryAssignment(
+            order=order,
+            courier=courier,
+            status=DeliveryAssignmentStatus.ACCEPTED,
+        )
+        log = DeliveryLog(
+            order=order,
+            assignment=assignment,
+            courier=courier,
+            status=DeliveryLogStatus.SUCCESS,
+            event_type="status_changed",
+            message="Order picked up",
+            payload={"actor": "courier"},
+        )
+
+        session.add_all([courier, order, assignment, log])
+        session.commit()
+        order_id = order.order_id
+        assignment_id = assignment.assignment_id
+        session.expunge_all()
+
+        loaded_order = session.scalars(
+            select(DeliveryOrder).where(DeliveryOrder.order_id == order_id)
+        ).one()
+
+        assert loaded_order.courier is not None
+        assert loaded_order.courier.full_name == "Иван Курьер"
+        assert loaded_order.assignments[0].status is DeliveryAssignmentStatus.ACCEPTED
+        assert loaded_order.logs[0].status is DeliveryLogStatus.SUCCESS
+        assert loaded_order.logs[0].assignment.assignment_id == assignment_id
+
+    engine.dispose()
+
+
+def test_delivery_order_amounts_cannot_be_negative() -> None:
+    """Ensure delivery orders respect non-negative amount checks."""
+
+    engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+    _create_all(engine)
+
+    with Session(engine) as session:
+        courier = Courier(
+            full_name="Никита Курьер",
+            phone="+79998887766",
+        )
+        order = DeliveryOrder(
+            courier=courier,
+            external_id="ORD-NEG",
+            status=DeliveryOrderStatus.NEW,
+            delivery_price=Decimal("-1.00"),
+        )
+
+        session.add(order)
+
+        with pytest.raises(IntegrityError):
+            session.commit()
+
+        session.rollback()
+
+    engine.dispose()

--- a/tests/test_db_repositories_delivery.py
+++ b/tests/test_db_repositories_delivery.py
@@ -1,0 +1,197 @@
+"""Unit tests for delivery repositories."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import Iterator
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from apps.mw.src.db.models import (
+    Base,
+    Courier,
+    CourierStatus,
+    DeliveryAssignment,
+    DeliveryAssignmentStatus,
+    DeliveryLog,
+    DeliveryLogStatus,
+    DeliveryOrder,
+    DeliveryOrderStatus,
+)
+from apps.mw.src.db.repositories.couriers import CourierRepository
+from apps.mw.src.db.repositories.delivery_assignments import (
+    DeliveryAssignmentRepository,
+)
+from apps.mw.src.db.repositories.delivery_logs import DeliveryLogRepository
+from apps.mw.src.db.repositories.delivery_orders import DeliveryOrderRepository
+
+
+@pytest.fixture()
+def session() -> Iterator[Session]:
+    engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+    Base.metadata.create_all(
+        engine,
+        tables=[
+            Courier.__table__,
+            DeliveryOrder.__table__,
+            DeliveryAssignment.__table__,
+            DeliveryLog.__table__,
+        ],
+    )
+    with Session(engine) as session:
+        yield session
+    engine.dispose()
+
+
+def test_courier_repository_crud(session: Session) -> None:
+    repo = CourierRepository(session)
+    courier = repo.create(
+        external_id="C-001",
+        full_name="Курьер Тестовый",
+        phone="+79990000000",
+        email="courier@example.com",
+        status=CourierStatus.ONBOARDING,
+        metadata={"region": "msk"},
+    )
+
+    assert courier.courier_id is not None
+    assert repo.get(courier.courier_id) is courier
+
+    repo.update_status(courier, CourierStatus.ACTIVE)
+    repo.update_contacts(courier, phone="+79991112233", metadata={"region": "spb"})
+
+    listed = repo.list_by_status(CourierStatus.ACTIVE)
+    assert listed == [courier]
+    assert courier.phone.endswith("2233")
+    assert courier.metadata_json == {"region": "spb"}
+
+    repo.delete(courier)
+    assert repo.get(courier.courier_id) is None
+
+
+def test_delivery_order_repository_flow(session: Session) -> None:
+    courier_repo = CourierRepository(session)
+    order_repo = DeliveryOrderRepository(session)
+
+    courier = courier_repo.create(
+        external_id="C-002",
+        full_name="Семен Курьер",
+        phone="+79993334455",
+        status=CourierStatus.ACTIVE,
+    )
+
+    order = order_repo.create(
+        external_id="ORD-001",
+        courier_id=courier.courier_id,
+        delivery_price=Decimal("250.00"),
+        cod_amount=Decimal("500.00"),
+        expected_delivery_at=datetime(2024, 4, 2, 12, 0, tzinfo=timezone.utc),
+        metadata={"priority": "high"},
+    )
+
+    assert order_repo.get(order.order_id) is order
+    assert order_repo.get_by_external_id("ORD-001") is order
+
+    active_orders = order_repo.list_active_for_courier(courier.courier_id)
+    assert active_orders == [order]
+
+    order_repo.update_status(order, DeliveryOrderStatus.DELIVERED, delivered_at=datetime.now(timezone.utc))
+    order_repo.assign_courier(order, courier_id=None)
+    order_repo.update_amounts(order, delivery_price=Decimal("260.00"))
+
+    assert order.status is DeliveryOrderStatus.DELIVERED
+    assert order.courier_id is None
+    assert order.delivery_price == Decimal("260.00")
+
+    order_repo.delete(order)
+    assert order_repo.get(order.order_id) is None
+
+
+def test_delivery_assignment_repository_flow(session: Session) -> None:
+    courier_repo = CourierRepository(session)
+    order_repo = DeliveryOrderRepository(session)
+    assignment_repo = DeliveryAssignmentRepository(session)
+
+    courier = courier_repo.create(
+        external_id="C-003",
+        full_name="Мария Курьер",
+        phone="+79995556677",
+        status=CourierStatus.ACTIVE,
+    )
+    order = order_repo.create(
+        external_id="ORD-ASSIGN",
+        courier_id=courier.courier_id,
+        status=DeliveryOrderStatus.READY,
+    )
+
+    assignment = assignment_repo.create(
+        order_id=order.order_id,
+        courier_id=courier.courier_id,
+        notes="Назначено автоматически",
+    )
+
+    assert assignment_repo.get(assignment.assignment_id) is assignment
+
+    active_assignments = assignment_repo.list_active_for_order(order.order_id)
+    assert active_assignments == [assignment]
+
+    assignment_repo.update_status(
+        assignment,
+        DeliveryAssignmentStatus.IN_PROGRESS,
+        accepted_at=datetime(2024, 4, 1, 9, 0, tzinfo=timezone.utc),
+    )
+    assignment_repo.reassign(
+        assignment,
+        courier_id=courier.courier_id,
+        notes="Подтверждение",
+    )
+    assignment_repo.update_status(
+        assignment,
+        DeliveryAssignmentStatus.COMPLETED,
+        completed_at=datetime(2024, 4, 1, 10, 0, tzinfo=timezone.utc),
+    )
+
+    assert assignment.status is DeliveryAssignmentStatus.COMPLETED
+    assert assignment.completed_at is not None
+
+    assignment_repo.delete(assignment)
+    assert assignment_repo.get(assignment.assignment_id) is None
+
+
+def test_delivery_log_repository_records_events(session: Session) -> None:
+    courier_repo = CourierRepository(session)
+    order_repo = DeliveryOrderRepository(session)
+    log_repo = DeliveryLogRepository(session)
+
+    courier = courier_repo.create(
+        external_id="C-004",
+        full_name="Антон Курьер",
+        phone="+79990009999",
+        status=CourierStatus.ACTIVE,
+    )
+    order = order_repo.create(
+        external_id="ORD-LOG",
+        courier_id=courier.courier_id,
+        status=DeliveryOrderStatus.ON_ROUTE,
+    )
+
+    log_entry = log_repo.create(
+        order_id=order.order_id,
+        status=DeliveryLogStatus.INFO,
+        event_type="status_change",
+        courier_id=courier.courier_id,
+        message="Заказ в пути",
+        payload={"location": "55.75,37.61"},
+    )
+
+    assert log_entry.id is not None
+
+    logs = log_repo.list_for_order(order.order_id)
+    assert logs == [log_entry]
+    assert logs[0].payload == {"location": "55.75,37.61"}
+
+    log_repo.delete(log_entry)
+    assert log_repo.list_for_order(order.order_id) == []


### PR DESCRIPTION
## Summary
- add courier, delivery order, assignment and log ORM models with typed statuses and relations
- create an Alembic migration that provisions the new delivery tables with constraints and indexes
- provide CRUD repositories and unit tests for the delivery persistence layer

## Testing
- PYTHONPATH=. pytest tests/test_db_models_delivery.py tests/test_db_repositories_delivery.py

------
https://chatgpt.com/codex/tasks/task_e_68d9611c3d54832a917c06bc9fb5283b