### PR TITLE
feat: add walking warehouse courier and order api

### DIFF
--- a/apps/mw/src/api/routes/ww.py
+++ b/apps/mw/src/api/routes/ww.py
@@ -1,0 +1,374 @@
+"""Walking Warehouse API endpoints."""
+from __future__ import annotations
+
+from uuid import uuid4
+from typing import Any, Iterable
+
+from fastapi import APIRouter, Depends, Path, Query, Response, status
+
+from apps.mw.src.api.dependencies import (
+    ProblemDetailException,
+    build_error,
+    enforce_idempotency_key,
+    provide_request_id,
+)
+from apps.mw.src.api.schemas import (
+    Courier,
+    CourierCreate,
+    CouriersResponse,
+    Error,
+    Order,
+    OrderAssign,
+    OrderCreate,
+    OrderCreateItem,
+    OrderListResponse,
+    OrderStatusUpdate,
+    OrderUpdate,
+    WWOrderStatus,
+)
+from apps.mw.src.integrations.ww import (
+    CourierAlreadyExistsError,
+    CourierNotFoundError,
+    OrderAlreadyExistsError,
+    OrderItemRecord,
+    OrderNotFoundError,
+    WalkingWarehouseCourierRepository,
+    WalkingWarehouseOrderRepository,
+)
+
+router = APIRouter(
+    prefix="/api/v1/ww",
+    tags=["walking-warehouse"],
+    dependencies=[Depends(provide_request_id)],
+)
+
+_courier_repository = WalkingWarehouseCourierRepository()
+_order_repository = WalkingWarehouseOrderRepository()
+
+
+def get_courier_repository() -> WalkingWarehouseCourierRepository:
+    """Dependency providing the courier repository."""
+
+    return _courier_repository
+
+
+def get_order_repository() -> WalkingWarehouseOrderRepository:
+    """Dependency providing the order repository."""
+
+    return _order_repository
+
+
+def _serialize_courier(record: object) -> Courier:
+    return Courier.model_validate(record)
+
+
+def _serialize_order(record: object) -> Order:
+    return Order.model_validate(record)
+
+
+def _serialize_items(items: Iterable[OrderCreateItem | dict[str, Any]]) -> list[OrderItemRecord]:
+    serialised: list[OrderItemRecord] = []
+    for item in items:
+        if isinstance(item, OrderCreateItem):
+            payload = item
+        else:
+            payload = OrderCreateItem.model_validate(item)
+        serialised.append(
+            OrderItemRecord(
+                sku=payload.sku,
+                name=payload.name,
+                qty=payload.qty,
+                price=payload.price,
+            )
+        )
+    return serialised
+
+
+@router.post(
+    "/couriers",
+    response_model=Courier,
+    status_code=status.HTTP_201_CREATED,
+    summary="Create courier",
+    responses={
+        status.HTTP_401_UNAUTHORIZED: {"model": Error, "description": "Missing principal."},
+        status.HTTP_403_FORBIDDEN: {"model": Error, "description": "Forbidden."},
+        status.HTTP_409_CONFLICT: {"model": Error, "description": "Courier already exists."},
+        status.HTTP_422_UNPROCESSABLE_ENTITY: {"model": Error, "description": "Validation error."},
+    },
+)
+async def create_courier(
+    payload: CourierCreate,
+    response: Response,
+    repository: WalkingWarehouseCourierRepository = Depends(get_courier_repository),
+    _idempotency_key: str = Depends(enforce_idempotency_key),
+) -> Courier:
+    """Register a new courier in the Walking Warehouse registry."""
+
+    try:
+        record = repository.create(
+            courier_id=payload.id,
+            display_name=payload.display_name,
+            phone=payload.phone,
+            is_active=payload.is_active,
+        )
+    except CourierAlreadyExistsError as exc:
+        error = build_error(
+            status.HTTP_409_CONFLICT,
+            title="Courier already exists",
+            detail=f"Courier {payload.id} already exists.",
+            request_id=response.headers.get("X-Request-Id"),
+        )
+        raise ProblemDetailException(error) from exc
+
+    response.headers["Location"] = f"/api/v1/ww/couriers/{record.id}"
+    return _serialize_courier(record)
+
+
+@router.get(
+    "/couriers",
+    response_model=CouriersResponse,
+    summary="List couriers",
+    responses={
+        status.HTTP_401_UNAUTHORIZED: {"model": Error, "description": "Missing principal."},
+        status.HTTP_403_FORBIDDEN: {"model": Error, "description": "Forbidden."},
+        status.HTTP_422_UNPROCESSABLE_ENTITY: {"model": Error, "description": "Validation error."},
+    },
+)
+def list_couriers(
+    repository: WalkingWarehouseCourierRepository = Depends(get_courier_repository),
+    q: str | None = Query(
+        default=None,
+        description="Case-insensitive search across courier id, name and phone.",
+        min_length=1,
+    ),
+) -> CouriersResponse:
+    """Retrieve couriers optionally filtered by a search query."""
+
+    records = repository.list(q=q)
+    return CouriersResponse(items=[_serialize_courier(record) for record in records])
+
+
+@router.post(
+    "/orders",
+    response_model=Order,
+    status_code=status.HTTP_201_CREATED,
+    summary="Create order",
+    responses={
+        status.HTTP_401_UNAUTHORIZED: {"model": Error, "description": "Missing principal."},
+        status.HTTP_403_FORBIDDEN: {"model": Error, "description": "Forbidden."},
+        status.HTTP_404_NOT_FOUND: {"model": Error, "description": "Related courier not found."},
+        status.HTTP_409_CONFLICT: {"model": Error, "description": "Order already exists."},
+        status.HTTP_422_UNPROCESSABLE_ENTITY: {"model": Error, "description": "Validation error."},
+    },
+)
+async def create_order(
+    payload: OrderCreate,
+    response: Response,
+    order_repository: WalkingWarehouseOrderRepository = Depends(get_order_repository),
+    courier_repository: WalkingWarehouseCourierRepository = Depends(get_courier_repository),
+    _idempotency_key: str = Depends(enforce_idempotency_key),
+) -> Order:
+    """Create a new instant order."""
+
+    if payload.courier_id is not None:
+        try:
+            courier_repository.get(payload.courier_id)
+        except CourierNotFoundError as exc:
+            error = build_error(
+                status.HTTP_404_NOT_FOUND,
+                title="Courier not found",
+                detail=f"Courier {payload.courier_id} was not found.",
+                request_id=response.headers.get("X-Request-Id"),
+            )
+            raise ProblemDetailException(error) from exc
+
+    order_id = payload.id or str(uuid4())
+    items = _serialize_items(payload.items)
+
+    try:
+        record = order_repository.create(
+            order_id=order_id,
+            title=payload.title,
+            customer_name=payload.customer_name,
+            status=payload.status.value if isinstance(payload.status, WWOrderStatus) else str(payload.status),
+            courier_id=payload.courier_id,
+            currency_code=payload.currency_code,
+            total_amount=payload.total_amount,
+            notes=payload.notes,
+            items=items,
+        )
+    except OrderAlreadyExistsError as exc:
+        error = build_error(
+            status.HTTP_409_CONFLICT,
+            title="Order already exists",
+            detail=f"Order {order_id} already exists.",
+            request_id=response.headers.get("X-Request-Id"),
+        )
+        raise ProblemDetailException(error) from exc
+
+    response.headers["Location"] = f"/api/v1/ww/orders/{record.id}"
+    return _serialize_order(record)
+
+
+@router.get(
+    "/orders",
+    response_model=OrderListResponse,
+    summary="List orders",
+    responses={
+        status.HTTP_401_UNAUTHORIZED: {"model": Error, "description": "Missing principal."},
+        status.HTTP_403_FORBIDDEN: {"model": Error, "description": "Forbidden."},
+        status.HTTP_422_UNPROCESSABLE_ENTITY: {"model": Error, "description": "Validation error."},
+    },
+)
+def list_orders(
+    order_repository: WalkingWarehouseOrderRepository = Depends(get_order_repository),
+    status_filter: list[WWOrderStatus] | None = Query(
+        default=None,
+        alias="status",
+        description="Filter by order status; multiple values allowed.",
+    ),
+    q: str | None = Query(
+        default=None,
+        description="Case-insensitive search across id, title and customer name.",
+        min_length=1,
+    ),
+) -> OrderListResponse:
+    """List orders optionally filtered by status and search query."""
+
+    statuses = None
+    if status_filter is not None:
+        statuses = [status.value for status in status_filter]
+
+    records = order_repository.list(statuses=statuses, q=q)
+    items = [_serialize_order(record) for record in records]
+    return OrderListResponse(items=items, total=len(items))
+
+
+@router.patch(
+    "/orders/{order_id}",
+    response_model=Order,
+    summary="Update order",
+    responses={
+        status.HTTP_401_UNAUTHORIZED: {"model": Error, "description": "Missing principal."},
+        status.HTTP_403_FORBIDDEN: {"model": Error, "description": "Forbidden."},
+        status.HTTP_404_NOT_FOUND: {"model": Error, "description": "Order not found."},
+        status.HTTP_422_UNPROCESSABLE_ENTITY: {"model": Error, "description": "Validation error."},
+    },
+)
+async def update_order(
+    payload: OrderUpdate,
+    response: Response,
+    order_id: str = Path(..., description="Identifier of the order to update."),
+    order_repository: WalkingWarehouseOrderRepository = Depends(get_order_repository),
+    _idempotency_key: str = Depends(enforce_idempotency_key),
+) -> Order:
+    """Apply partial updates to an order."""
+
+    update_data = payload.model_dump(exclude_unset=True)
+    items_payload = update_data.pop("items", None)
+    items = _serialize_items(items_payload) if items_payload is not None else None
+
+    try:
+        record = order_repository.update(
+            order_id,
+            title=update_data.get("title"),
+            customer_name=update_data.get("customer_name"),
+            notes=update_data.get("notes"),
+            items=items,
+            total_amount=update_data.get("total_amount"),
+            currency_code=update_data.get("currency_code"),
+        )
+    except OrderNotFoundError as exc:
+        error = build_error(
+            status.HTTP_404_NOT_FOUND,
+            title="Order not found",
+            detail=f"Order {order_id} was not found.",
+            request_id=response.headers.get("X-Request-Id"),
+        )
+        raise ProblemDetailException(error) from exc
+
+    return _serialize_order(record)
+
+
+@router.post(
+    "/orders/{order_id}/assign",
+    response_model=Order,
+    summary="Assign courier",
+    responses={
+        status.HTTP_401_UNAUTHORIZED: {"model": Error, "description": "Missing principal."},
+        status.HTTP_403_FORBIDDEN: {"model": Error, "description": "Forbidden."},
+        status.HTTP_404_NOT_FOUND: {"model": Error, "description": "Order or courier not found."},
+        status.HTTP_422_UNPROCESSABLE_ENTITY: {"model": Error, "description": "Validation error."},
+    },
+)
+async def assign_order(
+    payload: OrderAssign,
+    response: Response,
+    order_id: str = Path(..., description="Identifier of the order to update."),
+    order_repository: WalkingWarehouseOrderRepository = Depends(get_order_repository),
+    courier_repository: WalkingWarehouseCourierRepository = Depends(get_courier_repository),
+    _idempotency_key: str = Depends(enforce_idempotency_key),
+) -> Order:
+    """Assign or unassign a courier for an order."""
+
+    if payload.courier_id is not None:
+        try:
+            courier_repository.get(payload.courier_id)
+        except CourierNotFoundError as exc:
+            error = build_error(
+                status.HTTP_404_NOT_FOUND,
+                title="Courier not found",
+                detail=f"Courier {payload.courier_id} was not found.",
+                request_id=response.headers.get("X-Request-Id"),
+            )
+            raise ProblemDetailException(error) from exc
+
+    try:
+        record = order_repository.assign_courier(order_id, payload.courier_id)
+    except OrderNotFoundError as exc:
+        error = build_error(
+            status.HTTP_404_NOT_FOUND,
+            title="Order not found",
+            detail=f"Order {order_id} was not found.",
+            request_id=response.headers.get("X-Request-Id"),
+        )
+        raise ProblemDetailException(error) from exc
+
+    return _serialize_order(record)
+
+
+@router.post(
+    "/orders/{order_id}/status",
+    response_model=Order,
+    summary="Update order status",
+    responses={
+        status.HTTP_401_UNAUTHORIZED: {"model": Error, "description": "Missing principal."},
+        status.HTTP_403_FORBIDDEN: {"model": Error, "description": "Forbidden."},
+        status.HTTP_404_NOT_FOUND: {"model": Error, "description": "Order not found."},
+        status.HTTP_422_UNPROCESSABLE_ENTITY: {"model": Error, "description": "Validation error."},
+    },
+)
+async def update_order_status(
+    payload: OrderStatusUpdate,
+    response: Response,
+    order_id: str = Path(..., description="Identifier of the order to update."),
+    order_repository: WalkingWarehouseOrderRepository = Depends(get_order_repository),
+    _idempotency_key: str = Depends(enforce_idempotency_key),
+) -> Order:
+    """Transition an order to a new status."""
+
+    try:
+        record = order_repository.update_status(
+            order_id,
+            payload.status.value if isinstance(payload.status, WWOrderStatus) else str(payload.status),
+        )
+    except OrderNotFoundError as exc:
+        error = build_error(
+            status.HTTP_404_NOT_FOUND,
+            title="Order not found",
+            detail=f"Order {order_id} was not found.",
+            request_id=response.headers.get("X-Request-Id"),
+        )
+        raise ProblemDetailException(error) from exc
+
+    return _serialize_order(record)

--- a/apps/mw/src/api/schemas/__init__.py
+++ b/apps/mw/src/api/schemas/__init__.py
@@ -11,6 +11,20 @@ from .returns import (
     ReturnItem,
 )
 from .stt import STTDLQRequeueResponse, STTJobPayload
+from .ww import (
+    Courier,
+    CourierCreate,
+    CouriersResponse,
+    Order,
+    OrderAssign,
+    OrderCreate,
+    OrderCreateItem,
+    OrderItem,
+    OrderListResponse,
+    OrderStatusUpdate,
+    OrderUpdate,
+    WWOrderStatus,
+)
 
 __all__ = [
     "Error",
@@ -23,4 +37,16 @@ __all__ = [
     "ReturnItem",
     "STTDLQRequeueResponse",
     "STTJobPayload",
+    "Courier",
+    "CourierCreate",
+    "CouriersResponse",
+    "Order",
+    "OrderAssign",
+    "OrderCreate",
+    "OrderCreateItem",
+    "OrderItem",
+    "OrderListResponse",
+    "OrderStatusUpdate",
+    "OrderUpdate",
+    "WWOrderStatus",
 ]

--- a/apps/mw/src/api/schemas/ww.py
+++ b/apps/mw/src/api/schemas/ww.py
@@ -1,0 +1,192 @@
+"""Pydantic schemas for Walking Warehouse endpoints."""
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+from enum import Enum
+from typing import List
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class WWBaseModel(BaseModel):
+    """Base schema with common configuration for WW endpoints."""
+
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True, use_enum_values=True)
+
+
+class WWOrderStatus(str, Enum):
+    """Statuses available for Walking Warehouse instant orders."""
+
+    DRAFT = "DRAFT"
+    PENDING_APPROVAL = "PENDING_APPROVAL"
+    APPROVED = "APPROVED"
+    DELIVERED = "DELIVERED"
+    CANCELLED = "CANCELLED"
+    REJECTED = "REJECTED"
+    TIMEOUT_ESCALATED = "TIMEOUT_ESCALATED"
+
+
+class CourierCreate(WWBaseModel):
+    """Payload for creating a courier."""
+
+    id: str = Field(description="Unique identifier of the courier.")
+    display_name: str = Field(description="Human readable name of the courier.")
+    phone: str | None = Field(
+        default=None,
+        description="Contact phone number for the courier.",
+    )
+    is_active: bool = Field(
+        default=True,
+        description="Whether the courier is active and available for assignments.",
+    )
+
+
+class Courier(CourierCreate):
+    """Courier representation returned by the API."""
+
+    created_at: datetime = Field(description="Timestamp when the courier was registered.")
+    updated_at: datetime = Field(description="Timestamp of the last courier update.")
+
+
+class CouriersResponse(WWBaseModel):
+    """Collection of couriers."""
+
+    items: List[Courier] = Field(description="List of couriers matching the filters.")
+
+
+class OrderItemBase(WWBaseModel):
+    """Common fields for order items."""
+
+    sku: str = Field(description="Stock keeping unit of the product.")
+    name: str = Field(description="Human readable product name.")
+    qty: int = Field(ge=0, description="Quantity to be delivered.")
+    price: Decimal = Field(ge=0, description="Unit price in the order currency.")
+
+
+class OrderItem(OrderItemBase):
+    """Order line returned by the API."""
+
+
+class OrderCreateItem(OrderItemBase):
+    """Order line used in create and update payloads."""
+
+
+class Order(WWBaseModel):
+    """Representation of a Walking Warehouse instant order."""
+
+    id: str = Field(description="Unique identifier of the order.")
+    title: str = Field(description="Title of the order shown to the courier.")
+    customer_name: str = Field(description="Customer name associated with the order.")
+    status: WWOrderStatus = Field(description="Current status of the order workflow.")
+    courier_id: str | None = Field(
+        default=None,
+        description="Identifier of the courier assigned to the order.",
+    )
+    currency_code: str = Field(
+        description="ISO-4217 currency code of the order totals.",
+        min_length=3,
+        max_length=3,
+    )
+    total_amount: Decimal = Field(ge=0, description="Total amount including taxes and delivery.")
+    notes: str | None = Field(
+        default=None,
+        description="Optional notes displayed to the courier.",
+    )
+    created_at: datetime = Field(description="Timestamp when the order was created.")
+    updated_at: datetime = Field(description="Timestamp when the order was last updated.")
+    items: List[OrderItem] = Field(
+        description="Order lines for the courier to deliver.",
+        min_length=1,
+    )
+
+
+class OrderCreate(WWBaseModel):
+    """Payload for creating an instant order."""
+
+    id: str | None = Field(
+        default=None,
+        description="Optional identifier; generated when omitted.",
+    )
+    title: str = Field(description="Title of the order shown to the courier.")
+    customer_name: str = Field(description="Customer name associated with the order.")
+    status: WWOrderStatus = Field(
+        default=WWOrderStatus.DRAFT,
+        description="Initial status of the order.",
+    )
+    courier_id: str | None = Field(
+        default=None,
+        description="Identifier of the courier assigned to the order.",
+    )
+    currency_code: str = Field(
+        default="RUB",
+        description="ISO-4217 currency code of the order totals.",
+        min_length=3,
+        max_length=3,
+    )
+    total_amount: Decimal = Field(
+        ge=0,
+        description="Total amount including taxes and delivery.",
+    )
+    notes: str | None = Field(
+        default=None,
+        description="Optional notes displayed to the courier.",
+    )
+    items: List[OrderCreateItem] = Field(
+        description="Order lines for the courier to deliver.",
+        min_length=1,
+    )
+
+
+class OrderUpdate(WWBaseModel):
+    """Payload for updating an instant order."""
+
+    title: str | None = Field(
+        default=None,
+        description="Updated title of the order.",
+    )
+    customer_name: str | None = Field(
+        default=None,
+        description="Updated customer name.",
+    )
+    notes: str | None = Field(
+        default=None,
+        description="Updated notes for the courier.",
+    )
+    currency_code: str | None = Field(
+        default=None,
+        description="Updated currency code.",
+        min_length=3,
+        max_length=3,
+    )
+    total_amount: Decimal | None = Field(
+        default=None,
+        ge=0,
+        description="Updated order total.",
+    )
+    items: List[OrderCreateItem] | None = Field(
+        default=None,
+        description="Replacement set of order lines.",
+    )
+
+
+class OrderAssign(WWBaseModel):
+    """Payload assigning a courier to an order."""
+
+    courier_id: str | None = Field(
+        default=None,
+        description="Identifier of the courier or null to unassign.",
+    )
+
+
+class OrderStatusUpdate(WWBaseModel):
+    """Payload for transitioning an order to a new status."""
+
+    status: WWOrderStatus = Field(description="New status for the order.")
+
+
+class OrderListResponse(WWBaseModel):
+    """Collection of orders with metadata."""
+
+    items: List[Order] = Field(description="Orders matching requested filters.")
+    total: int = Field(ge=0, description="Total number of orders after filters.")

--- a/apps/mw/src/app.py
+++ b/apps/mw/src/app.py
@@ -21,6 +21,7 @@ from apps.mw.src.api.routes import call_registry as call_registry_router
 from apps.mw.src.api.routes import returns as returns_router
 from apps.mw.src.api.routes import stt_admin as stt_admin_router
 from apps.mw.src.api.routes import system as system_router
+from apps.mw.src.api.routes import ww as ww_router
 from apps.mw.src.api.schemas import Error, Health
 from apps.mw.src.health import get_health_payload
 from apps.mw.src.observability import (
@@ -42,6 +43,7 @@ app.include_router(b24_calls_router.router)
 app.include_router(call_registry_router.router)
 app.include_router(returns_router.router)
 app.include_router(stt_admin_router.router)
+app.include_router(ww_router.router)
 
 
 @app.on_event("startup")

--- a/apps/mw/src/integrations/__init__.py
+++ b/apps/mw/src/integrations/__init__.py
@@ -1,5 +1,5 @@
 """Integration clients for external systems."""
 
-from . import b24
+from . import b24, ww
 
-__all__ = ["b24"]
+__all__ = ["b24", "ww"]

--- a/apps/mw/src/integrations/ww/__init__.py
+++ b/apps/mw/src/integrations/ww/__init__.py
@@ -1,0 +1,23 @@
+"""Repositories for the Walking Warehouse integration."""
+
+from .repositories import (
+    CourierAlreadyExistsError,
+    CourierNotFoundError,
+    OrderAlreadyExistsError,
+    OrderItemRecord,
+    OrderNotFoundError,
+    OrderRecord,
+    WalkingWarehouseCourierRepository,
+    WalkingWarehouseOrderRepository,
+)
+
+__all__ = [
+    "CourierAlreadyExistsError",
+    "CourierNotFoundError",
+    "OrderAlreadyExistsError",
+    "OrderItemRecord",
+    "OrderNotFoundError",
+    "OrderRecord",
+    "WalkingWarehouseCourierRepository",
+    "WalkingWarehouseOrderRepository",
+]

--- a/apps/mw/src/integrations/ww/repositories.py
+++ b/apps/mw/src/integrations/ww/repositories.py
@@ -1,0 +1,246 @@
+"""In-memory repositories modelling Walking Warehouse storages."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import Iterable, Sequence
+
+
+def _utcnow() -> datetime:
+    """Return timezone-aware UTC timestamps."""
+
+    return datetime.now(timezone.utc)
+
+
+@dataclass(slots=True)
+class CourierRecord:
+    """Stored representation of a courier in Walking Warehouse."""
+
+    id: str
+    display_name: str
+    phone: str | None
+    is_active: bool
+    created_at: datetime
+    updated_at: datetime
+
+
+@dataclass(slots=True)
+class OrderItemRecord:
+    """Line item for a Walking Warehouse order."""
+
+    sku: str
+    name: str
+    qty: int
+    price: Decimal
+
+
+@dataclass(slots=True)
+class OrderRecord:
+    """Stored representation of an instant order from Walking Warehouse."""
+
+    id: str
+    title: str
+    customer_name: str
+    status: str
+    courier_id: str | None
+    currency_code: str
+    total_amount: Decimal
+    notes: str | None
+    created_at: datetime
+    updated_at: datetime
+    items: list[OrderItemRecord] = field(default_factory=list)
+
+
+class CourierAlreadyExistsError(RuntimeError):
+    """Raised when attempting to create a courier with a duplicate identifier."""
+
+
+class CourierNotFoundError(RuntimeError):
+    """Raised when a courier identifier cannot be resolved."""
+
+
+class OrderAlreadyExistsError(RuntimeError):
+    """Raised when attempting to create an order that already exists."""
+
+
+class OrderNotFoundError(RuntimeError):
+    """Raised when an order identifier cannot be found."""
+
+
+class WalkingWarehouseCourierRepository:
+    """Simple repository handling courier entities."""
+
+    def __init__(self) -> None:
+        self._couriers: dict[str, CourierRecord] = {}
+
+    def create(
+        self,
+        *,
+        courier_id: str,
+        display_name: str,
+        phone: str | None,
+        is_active: bool,
+    ) -> CourierRecord:
+        if courier_id in self._couriers:
+            raise CourierAlreadyExistsError(courier_id)
+
+        timestamp = _utcnow()
+        record = CourierRecord(
+            id=courier_id,
+            display_name=display_name,
+            phone=phone,
+            is_active=is_active,
+            created_at=timestamp,
+            updated_at=timestamp,
+        )
+        self._couriers[courier_id] = record
+        return record
+
+    def get(self, courier_id: str) -> CourierRecord:
+        record = self._couriers.get(courier_id)
+        if record is None:
+            raise CourierNotFoundError(courier_id)
+        return record
+
+    def list(self, *, q: str | None = None) -> list[CourierRecord]:
+        records = list(self._couriers.values())
+        if q:
+            needle = q.strip().lower()
+            if needle:
+                records = [
+                    courier
+                    for courier in records
+                    if needle in courier.display_name.lower()
+                    or needle in courier.id.lower()
+                    or (courier.phone or "").lower().find(needle) != -1
+                ]
+        records.sort(key=lambda courier: (courier.display_name.lower(), courier.id))
+        return records
+
+    def clear(self) -> None:
+        self._couriers.clear()
+
+
+class WalkingWarehouseOrderRepository:
+    """Simple repository handling order entities."""
+
+    def __init__(self) -> None:
+        self._orders: dict[str, OrderRecord] = {}
+
+    def create(
+        self,
+        *,
+        order_id: str,
+        title: str,
+        customer_name: str,
+        status: str,
+        courier_id: str | None,
+        currency_code: str,
+        total_amount: Decimal,
+        notes: str | None,
+        items: Sequence[OrderItemRecord],
+    ) -> OrderRecord:
+        if order_id in self._orders:
+            raise OrderAlreadyExistsError(order_id)
+
+        timestamp = _utcnow()
+        record = OrderRecord(
+            id=order_id,
+            title=title,
+            customer_name=customer_name,
+            status=status,
+            courier_id=courier_id,
+            currency_code=currency_code,
+            total_amount=total_amount,
+            notes=notes,
+            created_at=timestamp,
+            updated_at=timestamp,
+            items=list(items),
+        )
+        self._orders[order_id] = record
+        return record
+
+    def get(self, order_id: str) -> OrderRecord:
+        record = self._orders.get(order_id)
+        if record is None:
+            raise OrderNotFoundError(order_id)
+        return record
+
+    def list(
+        self,
+        *,
+        statuses: Iterable[str] | None = None,
+        q: str | None = None,
+    ) -> list[OrderRecord]:
+        records = list(self._orders.values())
+
+        if statuses:
+            allowed = {status.lower() for status in statuses}
+            records = [record for record in records if record.status.lower() in allowed]
+
+        if q:
+            needle = q.strip().lower()
+            if needle:
+                records = [
+                    record
+                    for record in records
+                    if needle in record.id.lower()
+                    or needle in record.title.lower()
+                    or needle in record.customer_name.lower()
+                ]
+
+        records.sort(key=lambda record: (record.created_at, record.id), reverse=True)
+        return records
+
+    def update(
+        self,
+        order_id: str,
+        *,
+        title: str | None = None,
+        customer_name: str | None = None,
+        notes: str | None = None,
+        items: Sequence[OrderItemRecord] | None = None,
+        total_amount: Decimal | None = None,
+        currency_code: str | None = None,
+    ) -> OrderRecord:
+        record = self.get(order_id)
+
+        updated = False
+        if title is not None:
+            record.title = title
+            updated = True
+        if customer_name is not None:
+            record.customer_name = customer_name
+            updated = True
+        if notes is not None:
+            record.notes = notes
+            updated = True
+        if items is not None:
+            record.items = list(items)
+            updated = True
+        if total_amount is not None:
+            record.total_amount = total_amount
+            updated = True
+        if currency_code is not None:
+            record.currency_code = currency_code
+            updated = True
+
+        if updated:
+            record.updated_at = _utcnow()
+        return record
+
+    def assign_courier(self, order_id: str, courier_id: str | None) -> OrderRecord:
+        record = self.get(order_id)
+        record.courier_id = courier_id
+        record.updated_at = _utcnow()
+        return record
+
+    def update_status(self, order_id: str, status: str) -> OrderRecord:
+        record = self.get(order_id)
+        record.status = status
+        record.updated_at = _utcnow()
+        return record
+
+    def clear(self) -> None:
+        self._orders.clear()

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -16,6 +16,8 @@ tags:
     description: Endpoints for managing merchandise returns.
   - name: b24-calls
     description: Bitrix24 call exports and registry endpoints.
+  - name: walking-warehouse
+    description: Walking Warehouse couriers and instant orders.
 paths:
   /health:
     get:
@@ -232,6 +234,489 @@ paths:
               $ref: '#/components/headers/XRequestId'
         '400':
           description: Invalid date range supplied.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+  /api/v1/ww/couriers:
+    get:
+      tags:
+        - walking-warehouse
+      summary: List Walking Warehouse couriers
+      description: Returns couriers optionally filtered by a search query.
+      operationId: listWalkingWarehouseCouriers
+      security:
+        - bearerAuth: []
+      x-roles:
+        - courier
+        - admin
+      parameters:
+        - $ref: '#/components/parameters/XRequestId'
+        - name: q
+          in: query
+          required: false
+          description: Case-insensitive search across courier id, name and phone.
+          schema:
+            type: string
+            minLength: 1
+      responses:
+        '200':
+          description: Collection of couriers.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CouriersResponse'
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+        '401':
+          description: Authentication required.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+        '403':
+          description: Principal lacks sufficient privileges.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+        '422':
+          description: Validation error.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+    post:
+      tags:
+        - walking-warehouse
+      summary: Register a Walking Warehouse courier
+      description: Creates a courier record for Walking Warehouse assignments.
+      operationId: createWalkingWarehouseCourier
+      security:
+        - bearerAuth: []
+      x-roles:
+        - admin
+      parameters:
+        - $ref: '#/components/parameters/XRequestId'
+        - $ref: '#/components/parameters/IdempotencyKey'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CourierCreate'
+      responses:
+        '201':
+          description: Courier created.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Courier'
+          headers:
+            Location:
+              description: URL of the created courier resource.
+              schema:
+                type: string
+                format: uri
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+        '401':
+          description: Authentication required.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+        '403':
+          description: Principal lacks sufficient privileges.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+        '409':
+          description: Courier already exists.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+        '422':
+          description: Validation error.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+  /api/v1/ww/orders:
+    get:
+      tags:
+        - walking-warehouse
+      summary: List Walking Warehouse orders
+      description: Returns instant orders optionally filtered by status and search query.
+      operationId: listWalkingWarehouseOrders
+      security:
+        - bearerAuth: []
+      x-roles:
+        - courier
+        - admin
+      parameters:
+        - $ref: '#/components/parameters/XRequestId'
+        - name: status
+          in: query
+          required: false
+          description: Filter orders by status; multiple values allowed.
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/WWOrderStatus'
+          style: form
+          explode: true
+        - name: q
+          in: query
+          required: false
+          description: Case-insensitive search across id, title and customer name.
+          schema:
+            type: string
+            minLength: 1
+      responses:
+        '200':
+          description: Collection of orders.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrderListResponse'
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+        '401':
+          description: Authentication required.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+        '403':
+          description: Principal lacks sufficient privileges.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+        '422':
+          description: Validation error.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+    post:
+      tags:
+        - walking-warehouse
+      summary: Create Walking Warehouse order
+      description: Creates a new instant order in Walking Warehouse.
+      operationId: createWalkingWarehouseOrder
+      security:
+        - bearerAuth: []
+      x-roles:
+        - courier
+        - admin
+      parameters:
+        - $ref: '#/components/parameters/XRequestId'
+        - $ref: '#/components/parameters/IdempotencyKey'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrderCreate'
+      responses:
+        '201':
+          description: Order created.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Order'
+          headers:
+            Location:
+              description: URL of the created order resource.
+              schema:
+                type: string
+                format: uri
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+        '401':
+          description: Authentication required.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+        '403':
+          description: Principal lacks sufficient privileges.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+        '404':
+          description: Referenced courier was not found.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+        '409':
+          description: Order already exists.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+        '422':
+          description: Validation error.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+  /api/v1/ww/orders/{order_id}:
+    parameters:
+      - $ref: '#/components/parameters/OrderId'
+    patch:
+      tags:
+        - walking-warehouse
+      summary: Update Walking Warehouse order
+      description: Applies partial updates to an existing instant order.
+      operationId: updateWalkingWarehouseOrder
+      security:
+        - bearerAuth: []
+      x-roles:
+        - courier
+        - admin
+      parameters:
+        - $ref: '#/components/parameters/XRequestId'
+        - $ref: '#/components/parameters/IdempotencyKey'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrderUpdate'
+      responses:
+        '200':
+          description: Updated order representation.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Order'
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+        '401':
+          description: Authentication required.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+        '403':
+          description: Principal lacks sufficient privileges.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+        '404':
+          description: Order was not found.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+        '422':
+          description: Validation error.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+  /api/v1/ww/orders/{order_id}/assign:
+    parameters:
+      - $ref: '#/components/parameters/OrderId'
+    post:
+      tags:
+        - walking-warehouse
+      summary: Assign courier to order
+      description: Assigns or unassigns a courier for an instant order.
+      operationId: assignWalkingWarehouseOrder
+      security:
+        - bearerAuth: []
+      x-roles:
+        - courier
+        - admin
+      parameters:
+        - $ref: '#/components/parameters/XRequestId'
+        - $ref: '#/components/parameters/IdempotencyKey'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrderAssign'
+      responses:
+        '200':
+          description: Updated order representation.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Order'
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+        '401':
+          description: Authentication required.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+        '403':
+          description: Principal lacks sufficient privileges.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+        '404':
+          description: Order or courier was not found.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+        '422':
+          description: Validation error.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+  /api/v1/ww/orders/{order_id}/status:
+    parameters:
+      - $ref: '#/components/parameters/OrderId'
+    post:
+      tags:
+        - walking-warehouse
+      summary: Update Walking Warehouse order status
+      description: Transitions an instant order to a new status.
+      operationId: updateWalkingWarehouseOrderStatus
+      security:
+        - bearerAuth: []
+      x-roles:
+        - courier
+        - admin
+      parameters:
+        - $ref: '#/components/parameters/XRequestId'
+        - $ref: '#/components/parameters/IdempotencyKey'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrderStatusUpdate'
+      responses:
+        '200':
+          description: Updated order representation.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Order'
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+        '401':
+          description: Authentication required.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+        '403':
+          description: Principal lacks sufficient privileges.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+        '404':
+          description: Order was not found.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+        '422':
+          description: Validation error.
           content:
             application/problem+json:
               schema:
@@ -821,6 +1306,281 @@ components:
           type: boolean
           description: Indicates if there is another page after the current one.
           example: true
+    Courier:
+      type: object
+      required:
+        - id
+        - display_name
+        - is_active
+        - created_at
+        - updated_at
+      properties:
+        id:
+          type: string
+          description: Unique identifier of the courier.
+          example: courier-101
+        display_name:
+          type: string
+          description: Human readable name of the courier.
+          example: John Doe
+        phone:
+          type: string
+          nullable: true
+          description: Contact phone number for the courier.
+          example: '+79001002030'
+        is_active:
+          type: boolean
+          description: Whether the courier is active and available for assignments.
+          example: true
+        created_at:
+          type: string
+          format: date-time
+          description: Timestamp when the courier was registered.
+          example: '2024-09-01T12:00:00Z'
+        updated_at:
+          type: string
+          format: date-time
+          description: Timestamp of the last courier update.
+          example: '2024-09-01T12:05:00Z'
+    CourierCreate:
+      type: object
+      required:
+        - id
+        - display_name
+      properties:
+        id:
+          type: string
+          description: Unique identifier of the courier.
+          example: courier-101
+        display_name:
+          type: string
+          description: Human readable name of the courier.
+          example: John Doe
+        phone:
+          type: string
+          nullable: true
+          description: Contact phone number for the courier.
+        is_active:
+          type: boolean
+          description: Whether the courier is active and available for assignments.
+          default: true
+    CouriersResponse:
+      type: object
+      required:
+        - items
+      properties:
+        items:
+          type: array
+          description: List of couriers matching the filters.
+          items:
+            $ref: '#/components/schemas/Courier'
+    WWOrderStatus:
+      type: string
+      description: Status values for Walking Warehouse instant orders.
+      enum:
+        - DRAFT
+        - PENDING_APPROVAL
+        - APPROVED
+        - DELIVERED
+        - CANCELLED
+        - REJECTED
+        - TIMEOUT_ESCALATED
+      example: APPROVED
+    OrderItem:
+      type: object
+      required:
+        - sku
+        - name
+        - qty
+        - price
+      properties:
+        sku:
+          type: string
+          description: Stock keeping unit of the product.
+          example: SKU-100
+        name:
+          type: string
+          description: Human readable product name.
+          example: Coffee
+        qty:
+          type: integer
+          minimum: 0
+          description: Quantity to be delivered.
+          example: 2
+        price:
+          type: string
+          description: Unit price in the order currency with two decimal places.
+          example: '250.00'
+    OrderCreateItem:
+      allOf:
+        - $ref: '#/components/schemas/OrderItem'
+    Order:
+      type: object
+      required:
+        - id
+        - title
+        - customer_name
+        - status
+        - currency_code
+        - total_amount
+        - created_at
+        - updated_at
+        - items
+      properties:
+        id:
+          type: string
+          description: Unique identifier of the order.
+          example: order-123
+        title:
+          type: string
+          description: Title of the order shown to the courier.
+          example: Grocery delivery
+        customer_name:
+          type: string
+          description: Customer name associated with the order.
+          example: Alice Smith
+        status:
+          $ref: '#/components/schemas/WWOrderStatus'
+        courier_id:
+          type: string
+          nullable: true
+          description: Identifier of the courier assigned to the order.
+          example: courier-101
+        currency_code:
+          type: string
+          minLength: 3
+          maxLength: 3
+          description: ISO-4217 currency code of the order totals.
+          example: RUB
+        total_amount:
+          type: string
+          description: Total amount including taxes and delivery with two decimal places.
+          example: '990.50'
+        notes:
+          type: string
+          nullable: true
+          description: Optional notes displayed to the courier.
+        created_at:
+          type: string
+          format: date-time
+          description: Timestamp when the order was created.
+          example: '2024-09-01T13:00:00Z'
+        updated_at:
+          type: string
+          format: date-time
+          description: Timestamp when the order was last updated.
+          example: '2024-09-01T13:05:00Z'
+        items:
+          type: array
+          minItems: 1
+          description: Order lines for the courier to deliver.
+          items:
+            $ref: '#/components/schemas/OrderItem'
+    OrderCreate:
+      type: object
+      required:
+        - title
+        - customer_name
+        - items
+        - total_amount
+      properties:
+        id:
+          type: string
+          nullable: true
+          description: Optional identifier; generated when omitted.
+          example: order-123
+        title:
+          type: string
+          description: Title of the order shown to the courier.
+          example: Grocery delivery
+        customer_name:
+          type: string
+          description: Customer name associated with the order.
+        status:
+          $ref: '#/components/schemas/WWOrderStatus'
+          description: Initial status of the order.
+          default: DRAFT
+        courier_id:
+          type: string
+          nullable: true
+          description: Identifier of the courier assigned to the order.
+        currency_code:
+          type: string
+          minLength: 3
+          maxLength: 3
+          description: ISO-4217 currency code of the order totals.
+          default: RUB
+        total_amount:
+          type: string
+          description: Total amount including taxes and delivery with two decimal places.
+          example: '990.50'
+        notes:
+          type: string
+          nullable: true
+          description: Optional notes displayed to the courier.
+        items:
+          type: array
+          minItems: 1
+          description: Order lines for the courier to deliver.
+          items:
+            $ref: '#/components/schemas/OrderCreateItem'
+    OrderUpdate:
+      type: object
+      properties:
+        title:
+          type: string
+          description: Updated title of the order.
+        customer_name:
+          type: string
+          description: Updated customer name.
+        notes:
+          type: string
+          nullable: true
+          description: Updated notes for the courier.
+        currency_code:
+          type: string
+          minLength: 3
+          maxLength: 3
+          description: Updated currency code.
+        total_amount:
+          type: string
+          description: Updated order total with two decimal places.
+        items:
+          type: array
+          description: Replacement set of order lines.
+          items:
+            $ref: '#/components/schemas/OrderCreateItem'
+    OrderAssign:
+      type: object
+      properties:
+        courier_id:
+          type: string
+          nullable: true
+          description: Identifier of the courier or null to unassign.
+    OrderStatusUpdate:
+      type: object
+      required:
+        - status
+      properties:
+        status:
+          $ref: '#/components/schemas/WWOrderStatus'
+          description: New status for the order.
+    OrderListResponse:
+      type: object
+      required:
+        - items
+        - total
+      properties:
+        items:
+          type: array
+          description: Orders matching requested filters.
+          items:
+            $ref: '#/components/schemas/Order'
+        total:
+          type: integer
+          minimum: 0
+          description: Total number of orders after filters.
+          example: 5
   parameters:
     XRequestId:
       name: X-Request-Id
@@ -862,6 +1622,13 @@ components:
       in: path
       required: true
       description: Identifier of the return.
+      schema:
+        type: string
+    OrderId:
+      name: order_id
+      in: path
+      required: true
+      description: Identifier of the Walking Warehouse order.
       schema:
         type: string
   headers:

--- a/tests/test_ww_api.py
+++ b/tests/test_ww_api.py
@@ -1,0 +1,225 @@
+"""Integration tests for Walking Warehouse API endpoints."""
+from __future__ import annotations
+
+from typing import Any
+from uuid import uuid4
+
+import httpx
+import pytest
+import pytest_asyncio
+
+from apps.mw.src.app import app
+from apps.mw.src.api.dependencies import reset_idempotency_cache
+from apps.mw.src.api.routes.ww import get_courier_repository, get_order_repository
+from apps.mw.src.integrations.ww import (
+    WalkingWarehouseCourierRepository,
+    WalkingWarehouseOrderRepository,
+)
+
+BASE_URL = "http://testserver"
+
+
+@pytest.fixture(autouse=True)
+def _reset_idempotency() -> None:
+    reset_idempotency_cache()
+    yield
+    reset_idempotency_cache()
+
+
+@pytest.fixture(autouse=True)
+def override_repositories() -> None:
+    courier_repo = WalkingWarehouseCourierRepository()
+    order_repo = WalkingWarehouseOrderRepository()
+    app.dependency_overrides[get_courier_repository] = lambda: courier_repo
+    app.dependency_overrides[get_order_repository] = lambda: order_repo
+    yield
+    app.dependency_overrides.pop(get_courier_repository, None)
+    app.dependency_overrides.pop(get_order_repository, None)
+
+
+@pytest_asyncio.fixture()
+async def api_client() -> httpx.AsyncClient:
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url=BASE_URL) as client:
+        yield client
+
+
+def _courier_payload(courier_id: str = "courier-1", **overrides: Any) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "id": courier_id,
+        "display_name": "John Doe",
+        "phone": "+79001002030",
+        "is_active": True,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _order_payload(order_id: str | None = None, courier_id: str | None = None, **overrides: Any) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "id": order_id,
+        "title": "Grocery delivery",
+        "customer_name": "Alice",
+        "status": "DRAFT",
+        "courier_id": courier_id,
+        "currency_code": "RUB",
+        "total_amount": "990.50",
+        "notes": "Deliver before 18:00",
+        "items": [
+            {
+                "sku": "SKU-100",
+                "name": "Coffee",
+                "qty": 2,
+                "price": "250.00",
+            },
+            {
+                "sku": "SKU-200",
+                "name": "Cookies",
+                "qty": 1,
+                "price": "490.50",
+            },
+        ],
+    }
+    payload.update(overrides)
+    return payload
+
+
+async def _create_courier(client: httpx.AsyncClient, courier_id: str = "courier-1") -> httpx.Response:
+    headers = {"Idempotency-Key": f"courier-{uuid4()}"}
+    return await client.post("/api/v1/ww/couriers", json=_courier_payload(courier_id), headers=headers)
+
+
+async def _create_order(
+    client: httpx.AsyncClient,
+    order_id: str | None = None,
+    courier_id: str | None = None,
+) -> httpx.Response:
+    headers = {"Idempotency-Key": f"order-{uuid4()}"}
+    return await client.post(
+        "/api/v1/ww/orders",
+        json=_order_payload(order_id=order_id, courier_id=courier_id),
+        headers=headers,
+    )
+
+
+@pytest.mark.asyncio
+async def test_courier_creation_and_listing(api_client: httpx.AsyncClient) -> None:
+    response = await _create_courier(api_client, "courier-101")
+    assert response.status_code == 201
+    body = response.json()
+    assert body["id"] == "courier-101"
+    assert response.headers["Location"].endswith("courier-101")
+
+    list_response = await api_client.get("/api/v1/ww/couriers")
+    assert list_response.status_code == 200
+    couriers = list_response.json()["items"]
+    assert any(courier["id"] == "courier-101" for courier in couriers)
+
+
+@pytest.mark.asyncio
+async def test_order_lifecycle_happy_path(api_client: httpx.AsyncClient) -> None:
+    await _create_courier(api_client, "courier-201")
+    await _create_courier(api_client, "courier-202")
+
+    create_response = await _create_order(api_client, courier_id="courier-201")
+    assert create_response.status_code == 201
+    order = create_response.json()
+    order_id = order["id"]
+    assert order["courier_id"] == "courier-201"
+
+    list_response = await api_client.get(
+        "/api/v1/ww/orders",
+        params=[("status", "DRAFT"), ("q", "grocery")],
+    )
+    assert list_response.status_code == 200
+    orders = list_response.json()["items"]
+    assert any(item["id"] == order_id for item in orders)
+
+    patch_headers = {"Idempotency-Key": f"patch-{uuid4()}"}
+    patch_payload = {
+        "title": "Updated grocery delivery",
+        "customer_name": "Alice Smith",
+        "currency_code": "RUB",
+        "total_amount": "1000.50",
+        "items": [
+            {
+                "sku": "SKU-100",
+                "name": "Coffee",
+                "qty": 3,
+                "price": "250.00",
+            }
+        ],
+    }
+    patch_response = await api_client.patch(
+        f"/api/v1/ww/orders/{order_id}", json=patch_payload, headers=patch_headers
+    )
+    assert patch_response.status_code == 200
+    updated = patch_response.json()
+    assert updated["title"] == "Updated grocery delivery"
+    assert updated["items"][0]["qty"] == 3
+
+    assign_headers = {"Idempotency-Key": f"assign-{uuid4()}"}
+    assign_response = await api_client.post(
+        f"/api/v1/ww/orders/{order_id}/assign",
+        json={"courier_id": "courier-202"},
+        headers=assign_headers,
+    )
+    assert assign_response.status_code == 200
+    assert assign_response.json()["courier_id"] == "courier-202"
+
+    status_headers = {"Idempotency-Key": f"status-{uuid4()}"}
+    status_response = await api_client.post(
+        f"/api/v1/ww/orders/{order_id}/status",
+        json={"status": "APPROVED"},
+        headers=status_headers,
+    )
+    assert status_response.status_code == 200
+    assert status_response.json()["status"] == "APPROVED"
+
+
+@pytest.mark.asyncio
+async def test_error_scenarios(api_client: httpx.AsyncClient) -> None:
+    await _create_courier(api_client, "courier-301")
+    duplicate_response = await _create_courier(api_client, "courier-301")
+    assert duplicate_response.status_code == 409
+
+    create_order_response = await _create_order(api_client, courier_id="missing-courier")
+    assert create_order_response.status_code == 404
+
+    missing_idempotency = await api_client.post(
+        "/api/v1/ww/orders",
+        json=_order_payload(courier_id="courier-301"),
+    )
+    assert missing_idempotency.status_code == 422
+    assert missing_idempotency.json()["title"] == "Invalid Idempotency-Key header"
+
+    headers = {"Idempotency-Key": f"update-{uuid4()}"}
+    update_missing = await api_client.patch(
+        f"/api/v1/ww/orders/{uuid4()}", json={"title": "noop"}, headers=headers
+    )
+    assert update_missing.status_code == 404
+
+    assign_headers = {"Idempotency-Key": f"assign-{uuid4()}"}
+    assign_response = await api_client.post(
+        f"/api/v1/ww/orders/{uuid4()}/assign",
+        json={"courier_id": "courier-301"},
+        headers=assign_headers,
+    )
+    assert assign_response.status_code == 404
+
+    assign_headers_existing = {"Idempotency-Key": f"assign-{uuid4()}"}
+    order_id = (await _create_order(api_client, courier_id="courier-301")).json()["id"]
+    assign_missing_courier = await api_client.post(
+        f"/api/v1/ww/orders/{order_id}/assign",
+        json={"courier_id": "unknown"},
+        headers=assign_headers_existing,
+    )
+    assert assign_missing_courier.status_code == 404
+
+    status_headers = {"Idempotency-Key": f"status-{uuid4()}"}
+    status_missing = await api_client.post(
+        f"/api/v1/ww/orders/{uuid4()}/status",
+        json={"status": "DELIVERED"},
+        headers=status_headers,
+    )
+    assert status_missing.status_code == 404


### PR DESCRIPTION
## Summary
- add Walking Warehouse router with courier and order endpoints backed by in-memory repositories
- define Pydantic schemas and repository helpers for WW couriers and instant orders
- register the router, extend the OpenAPI contract, and add integration tests covering happy path and error scenarios

## Testing
- PYTHONPATH=. pytest tests/test_ww_api.py


------
https://chatgpt.com/codex/tasks/task_e_68d9611c3a80832a9f5bdab0cec50a80