### PR TITLE
feat: add Walking Warehouse delivery log tracking

### DIFF
--- a/apps/mw/src/api/routes/ww_orders.py
+++ b/apps/mw/src/api/routes/ww_orders.py
@@ -1,0 +1,181 @@
+"""Walking Warehouse order management endpoints."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, Path, Response, status
+from sqlalchemy.orm import Session
+
+from apps.mw.src.api.dependencies import ProblemDetailException, build_error, provide_request_id
+from apps.mw.src.api.schemas import (
+    DeliveryLogEntry,
+    Error,
+    WWOrder,
+    WWOrderAssign,
+    WWOrderCreate,
+    WWOrderStatusChange,
+    WWOrderUpdate,
+)
+from apps.mw.src.db.models import DeliveryLog, DeliveryOrder, DeliveryOrderStatus
+from apps.mw.src.db.session import get_session
+from apps.mw.src.services.ww_orders import OrderNotFoundError, WWOrderService
+
+router = APIRouter(
+    prefix="/api/v1/ww/orders",
+    tags=["walking-warehouse"],
+    dependencies=[Depends(provide_request_id)],
+)
+
+
+def _serialize_order(order: DeliveryOrder) -> WWOrder:
+    return WWOrder(
+        id=str(order.order_id),
+        external_id=order.external_id,
+        status=order.status,
+        courier_id=order.courier_id,
+        payload=order.payload_json,
+        created_at=order.created_at,
+        updated_at=order.updated_at,
+    )
+
+
+def _serialize_log(entry: DeliveryLog) -> DeliveryLogEntry:
+    return DeliveryLogEntry(
+        id=entry.log_id,
+        order_id=str(entry.order_id),
+        actor=entry.actor,
+        action=entry.action,
+        payload=entry.payload_json,
+        created_at=entry.created_at,
+    )
+
+
+def _handle_not_found(order_id: UUID, response: Response) -> None:
+    problem = build_error(
+        status.HTTP_404_NOT_FOUND,
+        title="Order not found",
+        detail=f"Walking Warehouse order {order_id} was not found.",
+        request_id=response.headers.get("X-Request-Id"),
+    )
+    raise ProblemDetailException(problem)
+
+
+@router.post(
+    "",
+    response_model=WWOrder,
+    status_code=status.HTTP_201_CREATED,
+    responses={status.HTTP_409_CONFLICT: {"model": Error}},
+)
+def create_order(
+    payload: WWOrderCreate,
+    response: Response,
+    session: Session = Depends(get_session),
+) -> WWOrder:
+    service = WWOrderService(session)
+    order = service.create_order(
+        actor=payload.actor,
+        external_id=payload.external_id,
+        status=DeliveryOrderStatus(payload.status),
+        courier_id=payload.courier_id,
+        payload=payload.payload,
+    )
+    session.commit()
+    session.refresh(order)
+    response.headers["Location"] = f"/api/v1/ww/orders/{order.order_id}"
+    return _serialize_order(order)
+
+
+@router.put(
+    "/{order_id}",
+    response_model=WWOrder,
+    responses={status.HTTP_404_NOT_FOUND: {"model": Error}},
+)
+def update_order(
+    payload: WWOrderUpdate,
+    response: Response,
+    order_id: UUID = Path(..., description="Identifier of the Walking Warehouse order."),
+    session: Session = Depends(get_session),
+) -> WWOrder:
+    service = WWOrderService(session)
+    try:
+        order = service.update_order(
+            order_id,
+            actor=payload.actor,
+            courier_id=payload.courier_id,
+            payload=payload.payload,
+        )
+    except OrderNotFoundError:
+        _handle_not_found(order_id, response)
+    session.commit()
+    session.refresh(order)
+    return _serialize_order(order)
+
+
+@router.post(
+    "/{order_id}/assign",
+    response_model=WWOrder,
+    responses={status.HTTP_404_NOT_FOUND: {"model": Error}},
+)
+def assign_order(
+    payload: WWOrderAssign,
+    response: Response,
+    order_id: UUID = Path(..., description="Identifier of the Walking Warehouse order."),
+    session: Session = Depends(get_session),
+) -> WWOrder:
+    service = WWOrderService(session)
+    try:
+        order = service.assign_order(
+            order_id,
+            actor=payload.actor,
+            courier_id=payload.courier_id,
+        )
+    except OrderNotFoundError:
+        _handle_not_found(order_id, response)
+    session.commit()
+    session.refresh(order)
+    return _serialize_order(order)
+
+
+@router.post(
+    "/{order_id}/status",
+    response_model=WWOrder,
+    responses={status.HTTP_404_NOT_FOUND: {"model": Error}},
+)
+def change_status(
+    payload: WWOrderStatusChange,
+    response: Response,
+    order_id: UUID = Path(..., description="Identifier of the Walking Warehouse order."),
+    session: Session = Depends(get_session),
+) -> WWOrder:
+    service = WWOrderService(session)
+    try:
+        order = service.change_status(
+            order_id,
+            actor=payload.actor,
+            status=DeliveryOrderStatus(payload.status),
+            reason=payload.reason,
+        )
+    except OrderNotFoundError:
+        _handle_not_found(order_id, response)
+    session.commit()
+    session.refresh(order)
+    return _serialize_order(order)
+
+
+@router.get(
+    "/{order_id}/logs",
+    response_model=list[DeliveryLogEntry],
+    responses={status.HTTP_404_NOT_FOUND: {"model": Error}},
+)
+def list_logs(
+    response: Response,
+    order_id: UUID = Path(..., description="Identifier of the Walking Warehouse order."),
+    session: Session = Depends(get_session),
+) -> list[DeliveryLogEntry]:
+    service = WWOrderService(session)
+    try:
+        logs = service.list_logs(order_id)
+    except OrderNotFoundError:
+        _handle_not_found(order_id, response)
+    return [_serialize_log(entry) for entry in logs]

--- a/apps/mw/src/api/schemas/__init__.py
+++ b/apps/mw/src/api/schemas/__init__.py
@@ -11,6 +11,14 @@ from .returns import (
     ReturnItem,
 )
 from .stt import STTDLQRequeueResponse, STTJobPayload
+from .ww import (
+    DeliveryLogEntry,
+    WWOrder,
+    WWOrderAssign,
+    WWOrderCreate,
+    WWOrderStatusChange,
+    WWOrderUpdate,
+)
 
 __all__ = [
     "Error",
@@ -21,6 +29,12 @@ __all__ = [
     "ReturnCreate",
     "ReturnCreateItem",
     "ReturnItem",
+    "DeliveryLogEntry",
+    "WWOrder",
+    "WWOrderAssign",
+    "WWOrderCreate",
+    "WWOrderStatusChange",
+    "WWOrderUpdate",
     "STTDLQRequeueResponse",
     "STTJobPayload",
 ]

--- a/apps/mw/src/api/schemas/ww.py
+++ b/apps/mw/src/api/schemas/ww.py
@@ -1,0 +1,99 @@
+"""Pydantic schemas for Walking Warehouse order endpoints."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from apps.mw.src.db.models import DeliveryOrderStatus
+
+
+class APIModel(BaseModel):
+    """Base model enabling ORM mode with enum serialisation."""
+
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True, use_enum_values=True)
+
+
+class WWOrderCreate(APIModel):
+    """Payload accepted when creating a Walking Warehouse order."""
+
+    external_id: str = Field(description="Identifier of the order in the upstream system.")
+    status: DeliveryOrderStatus = Field(
+        default=DeliveryOrderStatus.DRAFT,
+        description="Initial status assigned to the order.",
+    )
+    courier_id: str | None = Field(
+        default=None,
+        description="Identifier of the courier currently responsible for the order.",
+    )
+    payload: dict[str, Any] | None = Field(
+        default=None,
+        description="Arbitrary metadata describing the order.",
+    )
+    actor: str = Field(description="Actor triggering the creation event.")
+
+
+class WWOrderUpdate(APIModel):
+    """Payload to mutate an existing Walking Warehouse order."""
+
+    courier_id: str | None = Field(
+        default=None,
+        description="Updated courier identifier for the order.",
+    )
+    payload: dict[str, Any] | None = Field(
+        default=None,
+        description="Replacement metadata for the order.",
+    )
+    actor: str = Field(description="Actor performing the update.")
+
+
+class WWOrderAssign(APIModel):
+    """Payload to assign a courier to an order."""
+
+    courier_id: str = Field(description="Identifier of the courier taking the order.")
+    actor: str = Field(description="Actor assigning the order.")
+
+
+class WWOrderStatusChange(APIModel):
+    """Payload to change the status of an order."""
+
+    status: DeliveryOrderStatus = Field(description="New status of the order.")
+    reason: str | None = Field(
+        default=None,
+        description="Optional reason describing the status transition.",
+    )
+    actor: str = Field(description="Actor changing the status.")
+
+
+class WWOrder(APIModel):
+    """Order representation returned by the API."""
+
+    id: str = Field(description="Primary identifier of the Walking Warehouse order.")
+    external_id: str = Field(description="Identifier in the source system.")
+    status: DeliveryOrderStatus = Field(description="Current status of the order.")
+    courier_id: str | None = Field(
+        default=None,
+        description="Assigned courier identifier, if any.",
+    )
+    payload: dict[str, Any] | None = Field(
+        default=None,
+        description="Metadata associated with the order.",
+    )
+    created_at: datetime = Field(description="Creation timestamp in UTC.")
+    updated_at: datetime = Field(description="Last update timestamp in UTC.")
+
+
+class DeliveryLogEntry(APIModel):
+    """Single event captured in the delivery log."""
+
+    id: int = Field(description="Identifier of the log entry.")
+    order_id: str = Field(description="Identifier of the order the event belongs to.")
+    actor: str = Field(description="Actor responsible for the event.")
+    action: str = Field(description="Machine readable action name.")
+    payload: dict[str, Any] | None = Field(
+        default=None,
+        description="Structured payload describing the event.",
+    )
+    created_at: datetime = Field(description="Timestamp when the log entry was created.")

--- a/apps/mw/src/app.py
+++ b/apps/mw/src/app.py
@@ -21,6 +21,7 @@ from apps.mw.src.api.routes import call_registry as call_registry_router
 from apps.mw.src.api.routes import returns as returns_router
 from apps.mw.src.api.routes import stt_admin as stt_admin_router
 from apps.mw.src.api.routes import system as system_router
+from apps.mw.src.api.routes import ww_orders as ww_orders_router
 from apps.mw.src.api.schemas import Error, Health
 from apps.mw.src.health import get_health_payload
 from apps.mw.src.observability import (
@@ -42,6 +43,7 @@ app.include_router(b24_calls_router.router)
 app.include_router(call_registry_router.router)
 app.include_router(returns_router.router)
 app.include_router(stt_admin_router.router)
+app.include_router(ww_orders_router.router)
 
 
 @app.on_event("startup")

--- a/apps/mw/src/db/__init__.py
+++ b/apps/mw/src/db/__init__.py
@@ -1,5 +1,19 @@
 """Database models exposed for seed scripts and tests."""
 
-from .models import Base, IntegrationLog, Return, ReturnLine
+from .models import (
+    Base,
+    DeliveryLog,
+    DeliveryOrder,
+    IntegrationLog,
+    Return,
+    ReturnLine,
+)
 
-__all__ = ["Base", "IntegrationLog", "Return", "ReturnLine"]
+__all__ = [
+    "Base",
+    "DeliveryLog",
+    "DeliveryOrder",
+    "IntegrationLog",
+    "Return",
+    "ReturnLine",
+]

--- a/apps/mw/src/db/repositories/__init__.py
+++ b/apps/mw/src/db/repositories/__init__.py
@@ -1,5 +1,10 @@
 """Repository helpers for database access patterns."""
 
+from .delivery_log import DeliveryLogRepository
 from .transcripts import B24TranscriptRepository, B24TranscriptSearchResult
 
-__all__ = ["B24TranscriptRepository", "B24TranscriptSearchResult"]
+__all__ = [
+    "B24TranscriptRepository",
+    "B24TranscriptSearchResult",
+    "DeliveryLogRepository",
+]

--- a/apps/mw/src/db/repositories/delivery_log.py
+++ b/apps/mw/src/db/repositories/delivery_log.py
@@ -1,0 +1,48 @@
+"""Repositories handling persistence of Walking Warehouse delivery logs."""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import Select, select
+from sqlalchemy.orm import Session
+
+from apps.mw.src.db.models import DeliveryLog
+
+
+class DeliveryLogRepository:
+    """Helper class to append and query delivery log entries."""
+
+    def __init__(self, session: Session) -> None:
+        self._session = session
+
+    def record(
+        self,
+        *,
+        order_id: UUID,
+        actor: str,
+        action: str,
+        payload: dict[str, Any] | None = None,
+    ) -> DeliveryLog:
+        """Persist a log entry for a Walking Warehouse order."""
+
+        entry = DeliveryLog(
+            order_id=order_id,
+            actor=actor,
+            action=action,
+            payload_json=payload,
+        )
+        self._session.add(entry)
+        self._session.flush()
+        return entry
+
+    def list_for_order(self, order_id: UUID) -> list[DeliveryLog]:
+        """Return log entries associated with the specified order."""
+
+        statement: Select[tuple[DeliveryLog]] = (
+            select(DeliveryLog)
+            .where(DeliveryLog.order_id == order_id)
+            .order_by(DeliveryLog.created_at.asc(), DeliveryLog.log_id.asc())
+        )
+        return list(self._session.scalars(statement))

--- a/apps/mw/src/services/__init__.py
+++ b/apps/mw/src/services/__init__.py
@@ -3,6 +3,7 @@
 from .call_download import download_call_record
 from .storage import StorageResult, StorageService
 from .summarizer import CallSummarizer, SummaryResult
+from .ww_orders import OrderNotFoundError, WWOrderService
 
 __all__ = [
     "download_call_record",
@@ -10,4 +11,6 @@ __all__ = [
     "StorageService",
     "CallSummarizer",
     "SummaryResult",
+    "OrderNotFoundError",
+    "WWOrderService",
 ]

--- a/apps/mw/src/services/ww_orders.py
+++ b/apps/mw/src/services/ww_orders.py
@@ -1,0 +1,144 @@
+"""Business logic helpers for Walking Warehouse orders."""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from apps.mw.src.db.models import DeliveryLog, DeliveryOrder, DeliveryOrderStatus
+from apps.mw.src.db.repositories.delivery_log import DeliveryLogRepository
+
+
+class OrderNotFoundError(LookupError):
+    """Raised when a requested order cannot be located in the database."""
+
+
+class WWOrderService:
+    """Encapsulates Walking Warehouse order workflows."""
+
+    def __init__(self, session: Session) -> None:
+        self._session = session
+        self._log_repo = DeliveryLogRepository(session)
+
+    def create_order(
+        self,
+        *,
+        actor: str,
+        external_id: str,
+        status: DeliveryOrderStatus = DeliveryOrderStatus.DRAFT,
+        courier_id: str | None = None,
+        payload: dict[str, Any] | None = None,
+    ) -> DeliveryOrder:
+        """Persist a new Walking Warehouse order and log the creation."""
+
+        order = DeliveryOrder(
+            external_id=external_id,
+            status=status,
+            courier_id=courier_id,
+            payload_json=payload,
+        )
+        self._session.add(order)
+        self._session.flush()
+        self._log_repo.record(
+            order_id=order.order_id,
+            actor=actor,
+            action="order_created",
+            payload={
+                "external_id": external_id,
+                "status": status.value,
+                "courier_id": courier_id,
+                "payload": payload,
+            },
+        )
+        return order
+
+    def update_order(
+        self,
+        order_id: UUID,
+        *,
+        actor: str,
+        courier_id: str | None = None,
+        payload: dict[str, Any] | None = None,
+    ) -> DeliveryOrder:
+        """Update mutable fields on an existing order and log the change."""
+
+        order = self._get_order(order_id)
+        changes: dict[str, Any] = {}
+
+        if courier_id is not None:
+            order.courier_id = courier_id
+            changes["courier_id"] = courier_id
+        if payload is not None:
+            order.payload_json = payload
+            changes["payload"] = payload
+
+        self._session.flush()
+        self._log_repo.record(
+            order_id=order.order_id,
+            actor=actor,
+            action="order_updated",
+            payload=changes or None,
+        )
+        return order
+
+    def assign_order(
+        self,
+        order_id: UUID,
+        *,
+        actor: str,
+        courier_id: str,
+    ) -> DeliveryOrder:
+        """Assign a courier to an order and log the operation."""
+
+        order = self._get_order(order_id)
+        order.courier_id = courier_id
+        self._session.flush()
+        self._log_repo.record(
+            order_id=order.order_id,
+            actor=actor,
+            action="order_assigned",
+            payload={"courier_id": courier_id},
+        )
+        return order
+
+    def change_status(
+        self,
+        order_id: UUID,
+        *,
+        actor: str,
+        status: DeliveryOrderStatus,
+        reason: str | None = None,
+    ) -> DeliveryOrder:
+        """Update the status of the order and log the transition."""
+
+        order = self._get_order(order_id)
+        order.status = status
+        self._session.flush()
+        payload: dict[str, Any] = {"status": status.value}
+        if reason:
+            payload["reason"] = reason
+        self._log_repo.record(
+            order_id=order.order_id,
+            actor=actor,
+            action="status_changed",
+            payload=payload,
+        )
+        return order
+
+    def list_logs(self, order_id: UUID) -> list[DeliveryLog]:
+        """Proxy to the repository for retrieving order logs."""
+
+        self._ensure_exists(order_id)
+        return self._log_repo.list_for_order(order_id)
+
+    def _get_order(self, order_id: UUID) -> DeliveryOrder:
+        order = self._session.get(DeliveryOrder, order_id)
+        if order is None:
+            raise OrderNotFoundError(str(order_id))
+        return order
+
+    def _ensure_exists(self, order_id: UUID) -> None:
+        if self._session.get(DeliveryOrder, order_id) is None:
+            raise OrderNotFoundError(str(order_id))

--- a/tests/test_db_delivery_log_repository.py
+++ b/tests/test_db_delivery_log_repository.py
@@ -1,0 +1,69 @@
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import Session
+from sqlalchemy.pool import StaticPool
+
+from apps.mw.src.db.models import (
+    Base,
+    DeliveryLog,
+    DeliveryOrder,
+    DeliveryOrderStatus,
+)
+from apps.mw.src.db.repositories.delivery_log import DeliveryLogRepository
+
+
+@pytest.fixture()
+def sqlite_engine() -> Engine:
+    engine = create_engine(
+        "sqlite+pysqlite:///:memory:",
+        future=True,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine, tables=[DeliveryOrder.__table__, DeliveryLog.__table__])
+    yield engine
+    engine.dispose()
+
+
+def test_record_and_list_delivery_logs(sqlite_engine: Engine) -> None:
+    session = Session(bind=sqlite_engine)
+    try:
+        order = DeliveryOrder(
+            external_id="ORD-001",
+            status=DeliveryOrderStatus.READY,
+        )
+        session.add(order)
+        session.flush()
+
+        repository = DeliveryLogRepository(session)
+        first = repository.record(
+            order_id=order.order_id,
+            actor="user:alice",
+            action="order_created",
+            payload={"status": order.status.value},
+        )
+        second = repository.record(
+            order_id=order.order_id,
+            actor="system",
+            action="status_changed",
+            payload={"status": DeliveryOrderStatus.DELIVERED.value},
+        )
+
+        logs = repository.list_for_order(order.order_id)
+        assert [entry.log_id for entry in logs] == [first.log_id, second.log_id]
+        assert logs[0].payload_json == {"status": DeliveryOrderStatus.READY.value}
+        assert logs[1].action == "status_changed"
+    finally:
+        session.close()
+
+
+def test_list_for_missing_order_returns_empty(sqlite_engine: Engine) -> None:
+    session = Session(bind=sqlite_engine)
+    try:
+        repository = DeliveryLogRepository(session)
+        assert repository.list_for_order(uuid4()) == []
+    finally:
+        session.close()

--- a/tests/test_ww_orders_logging.py
+++ b/tests/test_ww_orders_logging.py
@@ -1,0 +1,105 @@
+import httpx
+import pytest
+import pytest_asyncio
+from sqlalchemy import create_engine
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import Session
+from sqlalchemy.pool import StaticPool
+
+from apps.mw.src.app import app
+from apps.mw.src.db.models import Base, DeliveryLog, DeliveryOrder
+from apps.mw.src.db.session import configure_engine, engine as default_engine, get_session
+
+BASE_URL = "http://testserver"
+
+
+@pytest.fixture()
+def sqlite_engine() -> Engine:
+    engine = create_engine(
+        "sqlite+pysqlite:///:memory:",
+        future=True,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine, tables=[DeliveryOrder.__table__, DeliveryLog.__table__])
+    configure_engine(engine)
+    yield engine
+    configure_engine(default_engine)
+    engine.dispose()
+
+
+@pytest_asyncio.fixture()
+async def api_client(sqlite_engine: Engine) -> httpx.AsyncClient:
+    def override_session() -> Session:
+        session = Session(bind=sqlite_engine)
+        try:
+            yield session
+        finally:
+            session.close()
+
+    app.dependency_overrides[get_session] = override_session
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url=BASE_URL) as client:
+        yield client
+    app.dependency_overrides.pop(get_session, None)
+
+
+def _create_payload() -> dict[str, object]:
+    return {
+        "external_id": "WW-001",
+        "status": "ready",
+        "courier_id": None,
+        "payload": {"items": 2, "amount": 1990},
+        "actor": "user:manager-1",
+    }
+
+
+@pytest.mark.asyncio
+async def test_delivery_log_entries_created_for_order_lifecycle(api_client: httpx.AsyncClient) -> None:
+    create_response = await api_client.post("/api/v1/ww/orders", json=_create_payload())
+    assert create_response.status_code == 201
+    order = create_response.json()
+    order_id = order["id"]
+
+    logs_response = await api_client.get(f"/api/v1/ww/orders/{order_id}/logs")
+    assert logs_response.status_code == 200
+    logs = logs_response.json()
+    assert [entry["action"] for entry in logs] == ["order_created"]
+    assert logs[0]["actor"] == "user:manager-1"
+
+    update_payload = {
+        "courier_id": "courier-7",
+        "payload": {"items": 3, "note": "Updated order"},
+        "actor": "user:planner",
+    }
+    update_response = await api_client.put(f"/api/v1/ww/orders/{order_id}", json=update_payload)
+    assert update_response.status_code == 200
+    updated = update_response.json()
+    assert updated["courier_id"] == "courier-7"
+
+    assign_payload = {"courier_id": "courier-42", "actor": "system"}
+    assign_response = await api_client.post(
+        f"/api/v1/ww/orders/{order_id}/assign", json=assign_payload
+    )
+    assert assign_response.status_code == 200
+    assigned = assign_response.json()
+    assert assigned["courier_id"] == "courier-42"
+
+    status_payload = {"status": "delivered", "actor": "courier:42", "reason": "delivered"}
+    status_response = await api_client.post(
+        f"/api/v1/ww/orders/{order_id}/status", json=status_payload
+    )
+    assert status_response.status_code == 200
+    status_body = status_response.json()
+    assert status_body["status"] == "delivered"
+
+    final_logs_response = await api_client.get(f"/api/v1/ww/orders/{order_id}/logs")
+    assert final_logs_response.status_code == 200
+    final_logs = final_logs_response.json()
+    assert [entry["action"] for entry in final_logs] == [
+        "order_created",
+        "order_updated",
+        "order_assigned",
+        "status_changed",
+    ]
+    assert final_logs[-1]["payload"]["status"] == "delivered"


### PR DESCRIPTION
## Summary
- add DeliveryOrder and DeliveryLog models with repository helpers
- expose Walking Warehouse order endpoints that record audit entries
- cover repository and API lifecycle logging with dedicated tests

## Testing
- PYTHONPATH=. pytest tests/test_db_delivery_log_repository.py tests/test_ww_orders_logging.py

------
https://chatgpt.com/codex/tasks/task_e_68d9611e0a94832abf6324c35c1035ac