### PR TITLE
chore: configure Git LFS for 1C assets

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*.epf filter=lfs diff=lfs merge=lfs -text
+*.erf filter=lfs diff=lfs merge=lfs -text
+1c/config_dump_txt/**/*.txt filter=lfs diff=lfs merge=lfs -text

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,10 @@
 - Conventional Commits: `feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`.
 - Один PR — одна логическая задача.
 
+## Бинарные артефакты
+- Перед началом работы установите [Git LFS](https://git-lfs.com/) и выполните `git lfs install`.
+- Репозиторий хранит через LFS все `*.epf`, `*.erf` и дампы `1c/config_dump_txt/**/*.txt`.
+
 ## Код-стайл
 - ruff, mypy(strict), black (через ruff format).
 - Перед пушем: `make lint && make typecheck && make test`.


### PR DESCRIPTION
## Summary
- add a root .gitattributes that routes *.epf, *.erf, and 1c/config_dump_txt/**/*.txt files through Git LFS
- document the Git LFS requirement for contributors in the handbook

## Testing
- git lfs track
- git count-objects -vH

------
https://chatgpt.com/codex/tasks/task_e_68d96edd218c832a8e2663c50e4ec7c3