### PR TITLE
Add Walking Warehouse status mapping for KMP4 export

### DIFF
--- a/1c/README.md
+++ b/1c/README.md
@@ -7,6 +7,21 @@ This directory collects artifacts exported from the 1C platform that are consume
 
 The tree is designed to let automation discover configuration and vendor deliverables without relying on historical paths such as `core_subset/` or `src/`.
 
+## Walking Warehouse status mapping
+
+KMP4 expects Walking Warehouse order states to be normalized before upload. The middleware exports the following one-to-one mapping and fails fast when an unknown status appears:
+
+| WW status | KMP4 code | Description |
+| --- | --- | --- |
+| `NEW` | `new` | Order registered in MW and not yet assigned. |
+| `ASSIGNED` | `assigned_to_courier` | Courier picked up the task and is preparing the order. |
+| `IN_TRANSIT` | `courier_on_route` | Order is on the way to the customer. |
+| `DONE` | `completed` | Delivery finished, including cash handling. |
+| `REJECTED` | `cancelled_by_manager` | Order cancelled after manual review or customer refusal. |
+| `DECLINED` | `declined_by_courier` | Courier declined the task; MW re-queues the order. |
+
+The same table powers the `apps.mw` KMP4 export and is covered by automated tests to ensure the mapping stays in sync with the source enum.
+
 ## Automation helpers
 
 > **Prerequisites**

--- a/apps/mw/src/domain/ww_statuses.py
+++ b/apps/mw/src/domain/ww_statuses.py
@@ -1,0 +1,45 @@
+"""Mappings and helpers for Walking Warehouse status codes."""
+
+from __future__ import annotations
+
+from typing import Final
+
+from apps.mw.src.api.schemas.ww import WWOrderStatus
+
+
+class UnknownWWStatusError(ValueError):
+    """Raised when a Walking Warehouse status cannot be mapped to KMP4."""
+
+
+WW_TO_KMP4_STATUS: Final[dict[WWOrderStatus, str]] = {
+    WWOrderStatus.NEW: "new",
+    WWOrderStatus.ASSIGNED: "assigned_to_courier",
+    WWOrderStatus.IN_TRANSIT: "courier_on_route",
+    WWOrderStatus.DONE: "completed",
+    WWOrderStatus.REJECTED: "cancelled_by_manager",
+    WWOrderStatus.DECLINED: "declined_by_courier",
+}
+
+
+def map_ww_status_to_kmp4(status: WWOrderStatus | str) -> str:
+    """Translate a Walking Warehouse status into the KMP4 status code."""
+
+    if isinstance(status, WWOrderStatus):
+        status_enum = status
+    else:
+        try:
+            status_enum = WWOrderStatus(status)
+        except ValueError as exc:  # pragma: no cover - ValueError is re-raised with context
+            raise UnknownWWStatusError(
+                f"Unsupported Walking Warehouse status: {status!r}."
+            ) from exc
+
+    try:
+        return WW_TO_KMP4_STATUS[status_enum]
+    except KeyError as exc:  # pragma: no cover - defensive guard for unmapped statuses
+        raise UnknownWWStatusError(
+            f"No KMP4 status mapping defined for {status_enum.value!r}."
+        ) from exc
+
+
+__all__ = ["WW_TO_KMP4_STATUS", "map_ww_status_to_kmp4", "UnknownWWStatusError"]

--- a/apps/mw/src/integrations/ww/kmp4_export.py
+++ b/apps/mw/src/integrations/ww/kmp4_export.py
@@ -1,0 +1,74 @@
+"""Serialization helpers for exporting Walking Warehouse orders to KMP4."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from decimal import Decimal
+from typing import Any
+
+from apps.mw.src.domain.ww_statuses import (
+    UnknownWWStatusError,
+    map_ww_status_to_kmp4,
+)
+from apps.mw.src.integrations.ww.repositories import OrderItemRecord, OrderRecord
+
+
+class KMP4ExportError(RuntimeError):
+    """Raised when an order cannot be serialized for the KMP4 payload."""
+
+
+@dataclass(slots=True, frozen=True)
+class KMP4OrderPayload:
+    """Structured representation of a WW order expected by the KMP4 upload."""
+
+    order_id: str
+    title: str
+    customer_name: str
+    status_code: str
+    total_amount: Decimal
+    currency_code: str
+    courier_id: str | None
+    notes: str | None
+    created_at: datetime
+    updated_at: datetime
+    items: tuple[dict[str, Any], ...]
+
+
+def _serialize_item(item: OrderItemRecord) -> dict[str, Any]:
+    """Convert an order item into a serializable dictionary."""
+
+    return {
+        "sku": item.sku,
+        "name": item.name,
+        "qty": item.qty,
+        "price": str(item.price),
+    }
+
+
+def serialize_order(order: OrderRecord) -> KMP4OrderPayload:
+    """Map an order record into the structure consumed by KMP4."""
+
+    try:
+        status_code = map_ww_status_to_kmp4(order.status)
+    except UnknownWWStatusError as exc:  # pragma: no cover - handled in unit tests
+        raise KMP4ExportError(str(exc)) from exc
+
+    items = tuple(_serialize_item(item) for item in order.items)
+
+    return KMP4OrderPayload(
+        order_id=order.id,
+        title=order.title,
+        customer_name=order.customer_name,
+        status_code=status_code,
+        total_amount=order.total_amount,
+        currency_code=order.currency_code,
+        courier_id=order.courier_id,
+        notes=order.notes,
+        created_at=order.created_at,
+        updated_at=order.updated_at,
+        items=items,
+    )
+
+
+__all__ = ["KMP4ExportError", "KMP4OrderPayload", "serialize_order"]

--- a/docs/00‑Core — Синхронизация документации.md
+++ b/docs/00‑Core — Синхронизация документации.md
@@ -171,6 +171,18 @@ Status‑Dictionary v1
 3.2. Instant Orders (быстрые продажи курьера)
  DRAFT → PENDING_APPROVAL → APPROVED → (DELIVERED|CANCELLED)
  Отказы: REJECTED, эскалация тайм‑аута: TIMEOUT_ESCALATED.
+ KMP4 использует нормализованные коды статусов Walking Warehouse. Маппинг, закреплённый в `apps.mw` и тестах:
+
+| WW status | KMP4 code |
+| --- | --- |
+| NEW | new |
+| ASSIGNED | assigned_to_courier |
+| IN_TRANSIT | courier_on_route |
+| DONE | completed |
+| REJECTED | cancelled_by_manager |
+| DECLINED | declined_by_courier |
+
+Изменения словаря требуют обновления `WW_TO_KMP4_STATUS` и документации в `1c/README.md`.
 3.3. Возвраты (return / return_line)
 Подпроцесс: pending → accepted | rejected (cancelled — отмена заявки до обработки).
 Событие return_ready в MW переводит возврат в pending.

--- a/tests/test_ww_kmp4_export.py
+++ b/tests/test_ww_kmp4_export.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal
+
+import pytest
+
+from apps.mw.src.api.schemas.ww import WWOrderStatus
+from apps.mw.src.domain.ww_statuses import (
+    WW_TO_KMP4_STATUS,
+    UnknownWWStatusError,
+    map_ww_status_to_kmp4,
+)
+from apps.mw.src.integrations.ww.kmp4_export import (
+    KMP4ExportError,
+    KMP4OrderPayload,
+    serialize_order,
+)
+from apps.mw.src.integrations.ww.repositories import OrderItemRecord, OrderRecord
+
+
+def _order_record(status: str) -> OrderRecord:
+    timestamp = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    return OrderRecord(
+        id="order-1",
+        title="Sample order",
+        customer_name="Alice",
+        status=status,
+        courier_id="courier-1",
+        currency_code="RUB",
+        total_amount=Decimal("100.50"),
+        notes="Deliver before 18:00",
+        created_at=timestamp,
+        updated_at=timestamp,
+        items=[
+            OrderItemRecord(sku="SKU-1", name="Coffee", qty=1, price=Decimal("100.50"))
+        ],
+    )
+
+
+def test_mapping_covers_every_status() -> None:
+    mapped_statuses = set(WW_TO_KMP4_STATUS.keys())
+    assert mapped_statuses == set(WWOrderStatus)
+
+    for status in WWOrderStatus:
+        assert map_ww_status_to_kmp4(status) == WW_TO_KMP4_STATUS[status]
+        assert map_ww_status_to_kmp4(status.value) == WW_TO_KMP4_STATUS[status]
+
+
+def test_mapping_rejects_unknown_status() -> None:
+    with pytest.raises(UnknownWWStatusError):
+        map_ww_status_to_kmp4("UNKNOWN")
+
+
+def test_serialize_order_uses_mapping() -> None:
+    order = _order_record(WWOrderStatus.NEW.value)
+    payload = serialize_order(order)
+    assert isinstance(payload, KMP4OrderPayload)
+    assert payload.status_code == WW_TO_KMP4_STATUS[WWOrderStatus.NEW]
+
+
+def test_serialize_order_raises_for_unmapped_status() -> None:
+    order = _order_record("UNMAPPED")
+    with pytest.raises(KMP4ExportError) as excinfo:
+        serialize_order(order)
+    assert "UNMAPPED" in str(excinfo.value)


### PR DESCRIPTION
## Summary
- add a central `WW_TO_KMP4_STATUS` mapping and helper for Walking Warehouse statuses
- update the KMP4 export serializer to rely on the mapping and fail fast on unmapped statuses
- document the WW → KMP4 table in the 1C README and status glossary, and cover it with unit tests

## Testing
- PYTHONPATH=. pytest tests/test_ww_kmp4_export.py

------
https://chatgpt.com/codex/tasks/task_e_68d9829ebe30832a8928f935802a5f3d