### PR TITLE
feat: add Walking Warehouse reporting exports

### DIFF
--- a/apps/mw/src/api/schemas/__init__.py
+++ b/apps/mw/src/api/schemas/__init__.py
@@ -25,6 +25,14 @@ from .ww import (
     OrderUpdate,
     WWOrderStatus,
 )
+from .ww_reports import (
+    DeliveryReportResponse,
+    DeliveryReportRow,
+    DeliveryReportTotals,
+    KMP4ExportResponse,
+    KMP4Order,
+    KMP4OrderItem,
+)
 
 __all__ = [
     "Error",
@@ -49,4 +57,10 @@ __all__ = [
     "OrderStatusUpdate",
     "OrderUpdate",
     "WWOrderStatus",
+    "DeliveryReportResponse",
+    "DeliveryReportRow",
+    "DeliveryReportTotals",
+    "KMP4ExportResponse",
+    "KMP4Order",
+    "KMP4OrderItem",
 ]

--- a/apps/mw/src/api/schemas/ww_reports.py
+++ b/apps/mw/src/api/schemas/ww_reports.py
@@ -1,0 +1,138 @@
+"""Schemas for Walking Warehouse analytical endpoints."""
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+from typing import List
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class WWReportBaseModel(BaseModel):
+    """Base model configuration for report schemas."""
+
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
+
+
+class DeliveryReportRow(WWReportBaseModel):
+    """Single row in the delivery report response."""
+
+    order_id: str = Field(description="Identifier of the Walking Warehouse order.")
+    courier_id: str | None = Field(
+        default=None,
+        description="Identifier of the courier assigned to the order.",
+    )
+    courier_name: str | None = Field(
+        default=None,
+        description="Display name of the courier assigned to the order.",
+    )
+    status: str = Field(description="Current order status in Walking Warehouse.")
+    title: str = Field(description="Title of the delivery visible to the courier.")
+    customer_name: str = Field(description="Customer associated with the delivery.")
+    total_amount: Decimal = Field(
+        ge=0,
+        description="Total amount of the order in its currency.",
+    )
+    currency_code: str = Field(
+        description="ISO-4217 currency code of the order amount.",
+        min_length=3,
+        max_length=3,
+    )
+    created_at: datetime = Field(
+        description="Timestamp when the order was created in Walking Warehouse.",
+    )
+    updated_at: datetime = Field(
+        description="Timestamp when the order last changed status.",
+    )
+    duration_min: float = Field(
+        ge=0,
+        description="Elapsed minutes between creation and last update.",
+    )
+
+
+class DeliveryReportTotals(WWReportBaseModel):
+    """Aggregated totals for the delivery report."""
+
+    total_orders: int = Field(ge=0, description="Number of deliveries in the report.")
+    total_amount: Decimal = Field(
+        ge=0,
+        description="Sum of order totals across all deliveries.",
+    )
+    total_duration_min: float = Field(
+        ge=0,
+        description="Sum of delivery durations in minutes across the report.",
+    )
+
+
+class DeliveryReportResponse(WWReportBaseModel):
+    """Response payload returned by the delivery report endpoint."""
+
+    items: List[DeliveryReportRow] = Field(
+        description="Delivery records matching the requested filters.",
+    )
+    totals: DeliveryReportTotals = Field(
+        description="Aggregated totals for convenience in UI/export consumers.",
+    )
+
+
+class KMP4OrderItem(WWReportBaseModel):
+    """Order line included in the KMP4 export payload."""
+
+    sku: str = Field(description="Stock keeping unit used in Walking Warehouse.")
+    name: str = Field(description="Item name displayed to the courier.")
+    qty: int = Field(ge=0, description="Quantity of the item to deliver.")
+    price: str = Field(description="Unit price encoded as a decimal string.")
+
+
+class KMP4Order(WWReportBaseModel):
+    """Order payload compatible with the KMP4 upload extension."""
+
+    order_id: str = Field(description="Identifier of the order exported to KMP4.")
+    title: str = Field(description="Order title as displayed in the UI.")
+    customer_name: str = Field(description="Customer associated with the order.")
+    status_code: str = Field(description="Status code mapped to the KMP4 domain.")
+    total_amount: Decimal = Field(
+        ge=0,
+        description="Total amount of the order in its currency.",
+    )
+    currency_code: str = Field(
+        description="ISO-4217 currency code of the order amount.",
+        min_length=3,
+        max_length=3,
+    )
+    courier_id: str | None = Field(
+        default=None,
+        description="Identifier of the courier assigned to the order.",
+    )
+    notes: str | None = Field(
+        default=None,
+        description="Optional notes for the courier exported to KMP4.",
+    )
+    created_at: datetime = Field(
+        description="Timestamp when the order was created in Walking Warehouse.",
+    )
+    updated_at: datetime = Field(
+        description="Timestamp of the latest order change exported to KMP4.",
+    )
+    items: List[KMP4OrderItem] = Field(
+        description="Order lines included in the export payload.",
+    )
+
+
+class KMP4ExportResponse(WWReportBaseModel):
+    """Response containing orders serialized for KMP4."""
+
+    items: List[KMP4Order] = Field(
+        description="Orders ready to be consumed by the KMP4 extension.",
+    )
+    total: int = Field(ge=0, description="Number of orders in the export payload.")
+
+
+__all__ = [
+    "DeliveryReportResponse",
+    "DeliveryReportRow",
+    "DeliveryReportTotals",
+    "KMP4ExportResponse",
+    "KMP4Order",
+    "KMP4OrderItem",
+]

--- a/apps/mw/src/integrations/ww/repositories.py
+++ b/apps/mw/src/integrations/ww/repositories.py
@@ -172,12 +172,24 @@ class WalkingWarehouseOrderRepository:
         *,
         statuses: Iterable[str] | None = None,
         q: str | None = None,
+        courier_id: str | None = None,
+        created_from: datetime | None = None,
+        created_to: datetime | None = None,
     ) -> list[OrderRecord]:
         records = list(self._orders.values())
 
         if statuses:
             allowed = {status.lower() for status in statuses}
             records = [record for record in records if record.status.lower() in allowed]
+
+        if courier_id is not None:
+            records = [record for record in records if record.courier_id == courier_id]
+
+        if created_from is not None:
+            records = [record for record in records if record.created_at >= created_from]
+
+        if created_to is not None:
+            records = [record for record in records if record.created_at <= created_to]
 
         if q:
             needle = q.strip().lower()

--- a/apps/mw/src/services/ww_reports.py
+++ b/apps/mw/src/services/ww_reports.py
@@ -1,0 +1,137 @@
+"""Helpers generating Walking Warehouse analytical reports."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from decimal import Decimal
+from typing import Iterable
+
+from apps.mw.src.integrations.ww import (
+    CourierNotFoundError,
+    OrderRecord,
+    WalkingWarehouseCourierRepository,
+    WalkingWarehouseOrderRepository,
+)
+from apps.mw.src.integrations.ww.kmp4_export import KMP4OrderPayload, serialize_order
+
+
+@dataclass(slots=True)
+class DeliveryReportRow:
+    """Aggregated representation of a single Walking Warehouse delivery."""
+
+    order_id: str
+    courier_id: str | None
+    courier_name: str | None
+    status: str
+    title: str
+    customer_name: str
+    total_amount: Decimal
+    currency_code: str
+    created_at: datetime
+    updated_at: datetime
+    duration_min: float
+
+
+@dataclass(slots=True)
+class DeliveryReport:
+    """Collection of deliveries with accompanying totals."""
+
+    rows: list[DeliveryReportRow]
+    total_amount: Decimal
+    total_duration_min: float
+
+    @property
+    def total_orders(self) -> int:
+        return len(self.rows)
+
+
+class WWReportService:
+    """Domain service producing Walking Warehouse analytical exports."""
+
+    def __init__(
+        self,
+        order_repository: WalkingWarehouseOrderRepository,
+        courier_repository: WalkingWarehouseCourierRepository,
+    ) -> None:
+        self._order_repository = order_repository
+        self._courier_repository = courier_repository
+
+    def _resolve_courier_name(self, courier_id: str | None) -> str | None:
+        if courier_id is None:
+            return None
+        try:
+            courier = self._courier_repository.get(courier_id)
+        except CourierNotFoundError:
+            return None
+        return courier.display_name
+
+    @staticmethod
+    def _duration_minutes(order: OrderRecord) -> float:
+        delta = order.updated_at - order.created_at
+        return max(delta.total_seconds() / 60.0, 0.0)
+
+    def generate_delivery_report(
+        self,
+        *,
+        statuses: Iterable[str] | None = None,
+        courier_id: str | None = None,
+        created_from: datetime | None = None,
+        created_to: datetime | None = None,
+    ) -> DeliveryReport:
+        orders = self._order_repository.list(
+            statuses=statuses,
+            courier_id=courier_id,
+            created_from=created_from,
+            created_to=created_to,
+        )
+
+        rows: list[DeliveryReportRow] = []
+        total_amount = Decimal("0")
+        total_duration = 0.0
+        for order in orders:
+            courier_name = self._resolve_courier_name(order.courier_id)
+            duration_min = self._duration_minutes(order)
+            rows.append(
+                DeliveryReportRow(
+                    order_id=order.id,
+                    courier_id=order.courier_id,
+                    courier_name=courier_name,
+                    status=order.status,
+                    title=order.title,
+                    customer_name=order.customer_name,
+                    total_amount=order.total_amount,
+                    currency_code=order.currency_code,
+                    created_at=order.created_at,
+                    updated_at=order.updated_at,
+                    duration_min=duration_min,
+                )
+            )
+            total_amount += order.total_amount
+            total_duration += duration_min
+
+        return DeliveryReport(
+            rows=rows,
+            total_amount=total_amount,
+            total_duration_min=total_duration,
+        )
+
+    def build_kmp4_export(
+        self,
+        *,
+        statuses: Iterable[str] | None = None,
+        courier_id: str | None = None,
+        created_from: datetime | None = None,
+        created_to: datetime | None = None,
+    ) -> list[KMP4OrderPayload]:
+        orders = self._order_repository.list(
+            statuses=statuses,
+            courier_id=courier_id,
+            created_from=created_from,
+            created_to=created_to,
+        )
+
+        payloads = [serialize_order(order) for order in orders]
+        return payloads
+
+
+__all__ = ["DeliveryReport", "DeliveryReportRow", "WWReportService"]

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -724,6 +724,184 @@ paths:
           headers:
             X-Request-Id:
               $ref: '#/components/headers/XRequestId'
+  /api/v1/ww/report/deliveries:
+    get:
+      tags:
+        - walking-warehouse
+      summary: Walking Warehouse delivery report
+      description: >-
+        Returns Walking Warehouse deliveries filtered by optional parameters as a
+        structured report. Set `format=csv` to receive a UTF-8 encoded CSV with a
+        trailing totals row whose first column is `TOTALS` and whose
+        `total_amount`/`duration_min` columns contain aggregated sums.
+      operationId: getWalkingWarehouseDeliveryReport
+      parameters:
+        - $ref: '#/components/parameters/XRequestId'
+        - name: status
+          in: query
+          required: false
+          description: Filter by order status; multiple values allowed.
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/WWOrderStatus'
+        - name: courier_id
+          in: query
+          required: false
+          description: Filter deliveries handled by a specific courier identifier.
+          schema:
+            type: string
+            minLength: 1
+            maxLength: 128
+        - name: created_from
+          in: query
+          required: false
+          description: Return deliveries created on or after the specified timestamp.
+          schema:
+            type: string
+            format: date-time
+        - name: created_to
+          in: query
+          required: false
+          description: Return deliveries created on or before the specified timestamp.
+          schema:
+            type: string
+            format: date-time
+        - name: format
+          in: query
+          required: false
+          description: Response format; defaults to JSON. Use `csv` for a UTF-8 CSV export.
+          schema:
+            type: string
+            enum:
+              - json
+              - csv
+            default: json
+      responses:
+        '200':
+          description: Delivery report rendered in the requested format.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeliveryReportResponse'
+            text/csv:
+              schema:
+                type: string
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+        '401':
+          description: Authentication required.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+        '403':
+          description: Principal lacks sufficient privileges.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+        '422':
+          description: Validation error or invalid date range.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+  /api/v1/ww/export/kmp4:
+    get:
+      tags:
+        - walking-warehouse
+      summary: Walking Warehouse KMP4 export
+      description: Serializes deliveries into the payload consumed by the 1C KMP4 upload extension.
+      operationId: exportWalkingWarehouseKMP4
+      parameters:
+        - $ref: '#/components/parameters/XRequestId'
+        - name: status
+          in: query
+          required: false
+          description: Filter by order status; multiple values allowed.
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/WWOrderStatus'
+        - name: courier_id
+          in: query
+          required: false
+          description: Filter deliveries handled by a specific courier identifier.
+          schema:
+            type: string
+            minLength: 1
+            maxLength: 128
+        - name: created_from
+          in: query
+          required: false
+          description: Return deliveries created on or after the specified timestamp.
+          schema:
+            type: string
+            format: date-time
+        - name: created_to
+          in: query
+          required: false
+          description: Return deliveries created on or before the specified timestamp.
+          schema:
+            type: string
+            format: date-time
+      responses:
+        '200':
+          description: Orders serialized for the KMP4 upload extension.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KMP4ExportResponse'
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+        '401':
+          description: Authentication required.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+        '403':
+          description: Principal lacks sufficient privileges.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+        '422':
+          description: Validation error or invalid date range.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+        '500':
+          description: Unexpected serialization error.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
   /api/v1/b24-calls/export.json:
     get:
       tags:
@@ -1567,6 +1745,183 @@ components:
         status:
           $ref: '#/components/schemas/WWOrderStatus'
           description: New status for the order.
+    DeliveryReportRow:
+      type: object
+      required:
+        - order_id
+        - status
+        - title
+        - customer_name
+        - total_amount
+        - currency_code
+        - created_at
+        - updated_at
+        - duration_min
+      properties:
+        order_id:
+          type: string
+          description: Identifier of the Walking Warehouse order.
+        courier_id:
+          type: string
+          nullable: true
+          description: Identifier of the courier assigned to the order.
+        courier_name:
+          type: string
+          nullable: true
+          description: Display name of the courier assigned to the order.
+        status:
+          type: string
+          description: Current order status in Walking Warehouse.
+        title:
+          type: string
+          description: Title of the delivery visible to the courier.
+        customer_name:
+          type: string
+          description: Customer associated with the delivery.
+        total_amount:
+          type: string
+          description: Total amount of the order in its currency.
+        currency_code:
+          type: string
+          minLength: 3
+          maxLength: 3
+          description: ISO-4217 currency code of the order amount.
+        created_at:
+          type: string
+          format: date-time
+          description: Timestamp when the order was created in Walking Warehouse.
+        updated_at:
+          type: string
+          format: date-time
+          description: Timestamp when the order last changed status.
+        duration_min:
+          type: number
+          format: float
+          minimum: 0
+          description: Elapsed minutes between creation and last update.
+    DeliveryReportTotals:
+      type: object
+      required:
+        - total_orders
+        - total_amount
+        - total_duration_min
+      properties:
+        total_orders:
+          type: integer
+          minimum: 0
+          description: Number of deliveries in the report.
+        total_amount:
+          type: string
+          description: Sum of order totals across all deliveries.
+        total_duration_min:
+          type: number
+          format: float
+          minimum: 0
+          description: Sum of delivery durations in minutes across the report.
+    DeliveryReportResponse:
+      type: object
+      required:
+        - items
+        - totals
+      properties:
+        items:
+          type: array
+          description: Delivery records matching the requested filters.
+          items:
+            $ref: '#/components/schemas/DeliveryReportRow'
+        totals:
+          $ref: '#/components/schemas/DeliveryReportTotals'
+          description: Aggregated totals for convenience in UI/export consumers.
+    KMP4OrderItem:
+      type: object
+      required:
+        - sku
+        - name
+        - qty
+        - price
+      properties:
+        sku:
+          type: string
+          description: Stock keeping unit used in Walking Warehouse.
+        name:
+          type: string
+          description: Item name displayed to the courier.
+        qty:
+          type: integer
+          minimum: 0
+          description: Quantity of the item to deliver.
+        price:
+          type: string
+          description: Unit price encoded as a decimal string.
+    KMP4Order:
+      type: object
+      required:
+        - order_id
+        - title
+        - customer_name
+        - status_code
+        - total_amount
+        - currency_code
+        - created_at
+        - updated_at
+        - items
+      properties:
+        order_id:
+          type: string
+          description: Identifier of the order exported to KMP4.
+        title:
+          type: string
+          description: Order title as displayed in the UI.
+        customer_name:
+          type: string
+          description: Customer associated with the order.
+        status_code:
+          type: string
+          description: Status code mapped to the KMP4 domain.
+        total_amount:
+          type: string
+          description: Total amount of the order in its currency.
+        currency_code:
+          type: string
+          minLength: 3
+          maxLength: 3
+          description: ISO-4217 currency code of the order amount.
+        courier_id:
+          type: string
+          nullable: true
+          description: Identifier of the courier assigned to the order.
+        notes:
+          type: string
+          nullable: true
+          description: Optional notes for the courier exported to KMP4.
+        created_at:
+          type: string
+          format: date-time
+          description: Timestamp when the order was created in Walking Warehouse.
+        updated_at:
+          type: string
+          format: date-time
+          description: Timestamp of the latest order change exported to KMP4.
+        items:
+          type: array
+          description: Order lines included in the export payload.
+          items:
+            $ref: '#/components/schemas/KMP4OrderItem'
+    KMP4ExportResponse:
+      type: object
+      required:
+        - items
+        - total
+      properties:
+        items:
+          type: array
+          description: Orders ready to be consumed by the KMP4 extension.
+          items:
+            $ref: '#/components/schemas/KMP4Order'
+        total:
+          type: integer
+          minimum: 0
+          description: Number of orders in the export payload.
     OrderListResponse:
       type: object
       required:

--- a/tests/test_ww_api.py
+++ b/tests/test_ww_api.py
@@ -349,6 +349,7 @@ async def test_create_order_replay_returns_cached_response(
     assert assign_response.status_code == 404
 
     assign_headers_existing = {"Idempotency-Key": f"assign-{uuid4()}"}
+    await _create_courier(api_client, "courier-301")
     order_id = (await _create_order(api_client, courier_id="courier-301")).json()["id"]
     assign_missing_courier = await api_client.post(
         f"/api/v1/ww/orders/{order_id}/assign",

--- a/tests/test_ww_reports.py
+++ b/tests/test_ww_reports.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+
+import httpx
+import pytest
+import pytest_asyncio
+
+from apps.mw.src.api.dependencies import reset_idempotency_cache
+from apps.mw.src.api.routes.ww import (
+    get_courier_repository,
+    get_order_repository,
+)
+from apps.mw.src.api.schemas import WWOrderStatus
+from apps.mw.src.app import app
+from apps.mw.src.integrations.ww import (
+    OrderItemRecord,
+    WalkingWarehouseCourierRepository,
+    WalkingWarehouseOrderRepository,
+)
+
+BASE_URL = "http://testserver"
+
+
+@pytest.fixture(autouse=True)
+def _reset_idempotency() -> None:
+    reset_idempotency_cache()
+    yield
+    reset_idempotency_cache()
+
+
+@pytest.fixture()
+def ww_repositories() -> tuple[WalkingWarehouseCourierRepository, WalkingWarehouseOrderRepository]:
+    courier_repo = WalkingWarehouseCourierRepository()
+    order_repo = WalkingWarehouseOrderRepository()
+    app.dependency_overrides[get_courier_repository] = lambda: courier_repo
+    app.dependency_overrides[get_order_repository] = lambda: order_repo
+    yield courier_repo, order_repo
+    app.dependency_overrides.pop(get_courier_repository, None)
+    app.dependency_overrides.pop(get_order_repository, None)
+
+
+@pytest_asyncio.fixture()
+async def api_client() -> httpx.AsyncClient:
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url=BASE_URL) as client:
+        yield client
+
+
+def _seed_order(
+    order_repo: WalkingWarehouseOrderRepository,
+    *,
+    order_id: str,
+    courier_id: str | None,
+    status: WWOrderStatus,
+    created_at: datetime,
+    updated_at: datetime,
+    total_amount: Decimal,
+) -> None:
+    payload = order_repo.create(
+        order_id=order_id,
+        title=f"Delivery {order_id}",
+        customer_name="Alice",
+        status=status.value,
+        courier_id=courier_id,
+        currency_code="RUB",
+        total_amount=total_amount,
+        notes="Handle with care",
+        items=[
+            OrderItemRecord(
+                sku=f"SKU-{order_id}",
+                name="Coffee",
+                qty=1,
+                price=total_amount,
+            )
+        ],
+    )
+    payload.created_at = created_at
+    payload.updated_at = updated_at
+
+
+@pytest.mark.asyncio
+async def test_delivery_report_json_and_csv(
+    api_client: httpx.AsyncClient,
+    ww_repositories: tuple[WalkingWarehouseCourierRepository, WalkingWarehouseOrderRepository],
+) -> None:
+    courier_repo, order_repo = ww_repositories
+    courier_repo.create(
+        courier_id="courier-1",
+        display_name="Courier One",
+        phone="+79000000001",
+        is_active=True,
+    )
+    courier_repo.create(
+        courier_id="courier-2",
+        display_name="Courier Two",
+        phone="+79000000002",
+        is_active=True,
+    )
+
+    start = datetime(2024, 1, 1, 9, 0, tzinfo=timezone.utc)
+    _seed_order(
+        order_repo,
+        order_id="order-1",
+        courier_id="courier-1",
+        status=WWOrderStatus.DONE,
+        created_at=start,
+        updated_at=start + timedelta(minutes=45),
+        total_amount=Decimal("120.00"),
+    )
+    _seed_order(
+        order_repo,
+        order_id="order-2",
+        courier_id="courier-2",
+        status=WWOrderStatus.IN_TRANSIT,
+        created_at=start + timedelta(hours=1),
+        updated_at=start + timedelta(hours=1, minutes=15),
+        total_amount=Decimal("80.50"),
+    )
+
+    json_response = await api_client.get("/api/v1/ww/report/deliveries")
+    assert json_response.status_code == 200
+    body = json_response.json()
+    assert body["totals"]["total_orders"] == 2
+    assert body["totals"]["total_amount"] == "200.50"
+    assert body["totals"]["total_duration_min"] == pytest.approx(60.0)
+
+    item_ids = {item["order_id"] for item in body["items"]}
+    assert item_ids == {"order-1", "order-2"}
+    order_1 = next(item for item in body["items"] if item["order_id"] == "order-1")
+    assert order_1["courier_name"] == "Courier One"
+    assert order_1["duration_min"] == pytest.approx(45.0)
+
+    csv_response = await api_client.get(
+        "/api/v1/ww/report/deliveries",
+        params={"format": "csv"},
+    )
+    assert csv_response.status_code == 200
+    assert csv_response.headers["content-type"].startswith("text/csv")
+    assert csv_response.headers["content-disposition"].endswith("deliveries.csv")
+    csv_body = csv_response.text
+    assert csv_body.startswith("\ufeff")
+    lines = [line for line in csv_body.splitlines() if line]
+    assert lines[0].split(",")[0].lstrip("\ufeff") == "order_id"
+    assert any(line.startswith("order-1") for line in lines[1:-1])
+    assert lines[-1].startswith("TOTALS")
+    assert lines[-1].split(",")[6] == "200.50"
+    assert lines[-1].split(",")[-1] == "60.00"
+
+
+@pytest.mark.asyncio
+async def test_kmp4_export_payload(
+    api_client: httpx.AsyncClient,
+    ww_repositories: tuple[WalkingWarehouseCourierRepository, WalkingWarehouseOrderRepository],
+) -> None:
+    courier_repo, order_repo = ww_repositories
+    courier_repo.create(
+        courier_id="courier-77",
+        display_name="Courier Seventy Seven",
+        phone="+79000000077",
+        is_active=True,
+    )
+
+    base = datetime(2024, 2, 1, 10, 0, tzinfo=timezone.utc)
+    _seed_order(
+        order_repo,
+        order_id="order-kmp4",
+        courier_id="courier-77",
+        status=WWOrderStatus.NEW,
+        created_at=base,
+        updated_at=base + timedelta(minutes=5),
+        total_amount=Decimal("150.00"),
+    )
+
+    response = await api_client.get(
+        "/api/v1/ww/export/kmp4",
+        params={"status": WWOrderStatus.NEW.value},
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["total"] == 1
+    order = payload["items"][0]
+    assert order["order_id"] == "order-kmp4"
+    assert order["status_code"] == "new"
+    assert order["total_amount"] == "150.00"
+    assert order["courier_id"] == "courier-77"
+    assert order["items"][0]["price"] == "150.00"
+


### PR DESCRIPTION
## Summary
- add Walking Warehouse delivery report and KMP4 export endpoints with CSV handling, validation, and metrics wiring
- introduce reporting schemas and service helpers plus repository filters for status, courier, and date ranges
- document the new APIs in openapi.yaml and extend tests to cover JSON/CSV responses and KMP4 payloads

## Testing
- PYTHONPATH=. pytest tests/test_ww_reports.py tests/test_ww_api.py tests/test_ww_kmp4_export.py

------
https://chatgpt.com/codex/tasks/task_e_68d9880fd4d0832a8f7ebd18712f939c