### PR TITLE
feat(ww): add assignment accept and decline flow

### DIFF
--- a/apps/mw/src/api/schemas/ww.py
+++ b/apps/mw/src/api/schemas/ww.py
@@ -26,6 +26,14 @@ class WWOrderStatus(str, Enum):
     DECLINED = "DECLINED"
 
 
+class WWAssignmentStatus(str, Enum):
+    """Statuses describing the lifecycle of a courier assignment."""
+
+    PENDING = "PENDING"
+    ACCEPTED = "ACCEPTED"
+    DECLINED = "DECLINED"
+
+
 class CourierCreate(WWBaseModel):
     """Payload for creating a courier."""
 
@@ -193,3 +201,41 @@ class OrderListResponse(WWBaseModel):
 
     items: List[Order] = Field(description="Orders matching requested filters.")
     total: int = Field(ge=0, description="Total number of orders after filters.")
+
+
+class Assignment(WWBaseModel):
+    """Representation of an order assignment for a courier."""
+
+    id: str = Field(description="Unique identifier of the assignment.")
+    order_id: str = Field(description="Identifier of the linked order.")
+    courier_id: str = Field(description="Identifier of the assigned courier.")
+    status: WWAssignmentStatus = Field(description="Current state of the assignment.")
+    created_at: datetime = Field(description="Timestamp when the assignment was created.")
+    updated_at: datetime = Field(description="Timestamp when the assignment was last updated.")
+
+
+class AssignmentAcceptRequest(WWBaseModel):
+    """Payload confirming that a courier accepted an assignment."""
+
+    comment: str | None = Field(
+        default=None,
+        description="Optional comment accompanying the acceptance.",
+        max_length=500,
+    )
+
+
+class AssignmentDeclineRequest(WWBaseModel):
+    """Payload sent when a courier declines an assignment."""
+
+    reason: str | None = Field(
+        default=None,
+        description="Optional reason for declining the assignment.",
+        max_length=500,
+    )
+
+
+class AssignmentActionResponse(WWBaseModel):
+    """Response wrapper carrying both assignment and order state."""
+
+    assignment: Assignment = Field(description="Updated assignment information.")
+    order: Order = Field(description="Current state of the linked order.")

--- a/apps/mw/src/integrations/ww/__init__.py
+++ b/apps/mw/src/integrations/ww/__init__.py
@@ -1,12 +1,16 @@
 """Repositories for the Walking Warehouse integration."""
 
 from .repositories import (
+    AssignmentAlreadyExistsError,
+    AssignmentNotFoundError,
+    InvalidAssignmentStatusTransitionError,
     CourierAlreadyExistsError,
     CourierNotFoundError,
     OrderAlreadyExistsError,
     OrderItemRecord,
     OrderNotFoundError,
     OrderRecord,
+    WalkingWarehouseAssignmentRepository,
     WalkingWarehouseCourierRepository,
     WalkingWarehouseOrderRepository,
 )
@@ -22,6 +26,10 @@ __all__ = [
     "OrderItemRecord",
     "OrderNotFoundError",
     "OrderRecord",
+    "AssignmentAlreadyExistsError",
+    "AssignmentNotFoundError",
+    "InvalidAssignmentStatusTransitionError",
+    "WalkingWarehouseAssignmentRepository",
     "WalkingWarehouseCourierRepository",
     "WalkingWarehouseOrderRepository",
     "InvalidOrderStatusTransitionError",


### PR DESCRIPTION
## Summary
- extend the Walking Warehouse in-memory repositories with assignment records, status checks, and order reset helper
- add Pydantic models for assignment accept/decline operations and expose new FastAPI endpoints that keep orders in sync via the state machine
- cover the new endpoints with async API tests to assert happy-path acceptance and decline-driven resets

## Testing
- `PYTHONPATH=. pytest tests/test_ww_api.py` *(fails: missing pytest_asyncio dependency in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da1bab10f0832a8188d85e56f8cadd