### PR TITLE
feat: add Walking Warehouse order status logs

### DIFF
--- a/apps/mw/src/api/schemas/__init__.py
+++ b/apps/mw/src/api/schemas/__init__.py
@@ -12,6 +12,10 @@ from .returns import (
 )
 from .stt import STTDLQRequeueResponse, STTJobPayload
 from .ww import (
+    Assignment,
+    AssignmentAcceptRequest,
+    AssignmentActionResponse,
+    AssignmentDeclineRequest,
     Courier,
     CourierCreate,
     CouriersResponse,
@@ -21,8 +25,11 @@ from .ww import (
     OrderCreateItem,
     OrderItem,
     OrderListResponse,
+    OrderStatusLogEntry,
+    OrderStatusLogResponse,
     OrderStatusUpdate,
     OrderUpdate,
+    WWAssignmentStatus,
     WWOrderStatus,
 )
 from .ww_reports import (
@@ -45,6 +52,10 @@ __all__ = [
     "ReturnItem",
     "STTDLQRequeueResponse",
     "STTJobPayload",
+    "Assignment",
+    "AssignmentAcceptRequest",
+    "AssignmentActionResponse",
+    "AssignmentDeclineRequest",
     "Courier",
     "CourierCreate",
     "CouriersResponse",
@@ -54,8 +65,11 @@ __all__ = [
     "OrderCreateItem",
     "OrderItem",
     "OrderListResponse",
+    "OrderStatusLogEntry",
+    "OrderStatusLogResponse",
     "OrderStatusUpdate",
     "OrderUpdate",
+    "WWAssignmentStatus",
     "WWOrderStatus",
     "DeliveryReportResponse",
     "DeliveryReportRow",

--- a/apps/mw/src/api/schemas/ww.py
+++ b/apps/mw/src/api/schemas/ww.py
@@ -194,6 +194,55 @@ class OrderStatusUpdate(WWBaseModel):
     """Payload for transitioning an order to a new status."""
 
     status: WWOrderStatus = Field(description="New status for the order.")
+    lat: float | None = Field(
+        default=None,
+        ge=-90,
+        le=90,
+        description="Optional latitude of the courier when the update was sent.",
+    )
+    lon: float | None = Field(
+        default=None,
+        ge=-180,
+        le=180,
+        description="Optional longitude of the courier when the update was sent.",
+    )
+    note: str | None = Field(
+        default=None,
+        max_length=500,
+        description="Optional note accompanying the status update.",
+    )
+
+
+class OrderStatusLogEntry(WWBaseModel):
+    """Representation of a persisted order status update event."""
+
+    status: WWOrderStatus = Field(description="Order status recorded in the log entry.")
+    lat: float | None = Field(
+        default=None,
+        ge=-90,
+        le=90,
+        description="Latitude reported for the update.",
+    )
+    lon: float | None = Field(
+        default=None,
+        ge=-180,
+        le=180,
+        description="Longitude reported for the update.",
+    )
+    note: str | None = Field(
+        default=None,
+        max_length=500,
+        description="Additional note captured with the update.",
+    )
+    created_at: datetime = Field(description="Timestamp when the log entry was created.")
+
+
+class OrderStatusLogResponse(WWBaseModel):
+    """Collection wrapper for order status log entries."""
+
+    items: List[OrderStatusLogEntry] = Field(
+        description="List of log entries ordered from oldest to newest.",
+    )
 
 
 class OrderListResponse(WWBaseModel):


### PR DESCRIPTION
## Summary
- allow Walking Warehouse status updates to carry optional latitude, longitude, and notes and expose them through a new logs schema
- persist status update payloads as order log entries while emitting structured logs for each transition
- extend async WW API tests to exercise the PATCH status flow and the new order logs endpoint

## Testing
- PYTHONPATH=. pytest tests/test_ww_api.py

------
https://chatgpt.com/codex/tasks/task_e_68da1fb9a314832aa82bc5d8f4a9c2ad