### PR TITLE
Add dev override compose with random db and redis ports

### DIFF
--- a/docker-compose.dev.override.yml
+++ b/docker-compose.dev.override.yml
@@ -1,0 +1,5 @@
+services:
+  db:
+    ports: ["0:5432"]
+  redis:
+    ports: ["0:6379"]


### PR DESCRIPTION
## Summary
- add docker-compose.dev.override.yml to expose db and redis on random host ports for development

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dbc4e69014832a8c2e3edfe153af4f