### PR TITLE
Fix Walking Warehouse log forwarding instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,19 +119,19 @@ worker:
 	fi
 
 1c-pack-kmp4:
-        @mkdir -p "$(ONEC_LOG_DIR)"
-        @LOG="$(ONEC_PACK_LOG)"; \
-        ARTIFACT="$(ONEC_PACK_ARTIFACT)"; \
-        if "$(POWERSHELL)" -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "$(ONEC_PACK_SCRIPT)" -SourceDirectory "$(ONEC_PACK_SOURCE)" -OutputFile "$(ONEC_PACK_ARTIFACT)" > "$$LOG" 2>&1; then \
-                cat "$$LOG"; \
-                if [ ! -f "$$ARTIFACT" ]; then \
-                        echo "Expected artifact $$ARTIFACT to be created." >&2; \
-                        exit 1; \
-                fi; \
-        else \
-                cat "$$LOG"; \
-                exit 1; \
-        fi
+	@mkdir -p "$(ONEC_LOG_DIR)"
+	@LOG="$(ONEC_PACK_LOG)"; \
+	ARTIFACT="$(ONEC_PACK_ARTIFACT)"; \
+	if "$(POWERSHELL)" -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "$(ONEC_PACK_SCRIPT)" -SourceDirectory "$(ONEC_PACK_SOURCE)" -OutputFile "$(ONEC_PACK_ARTIFACT)" > "$$LOG" 2>&1; then \
+		cat "$$LOG"; \
+		if [ ! -f "$$ARTIFACT" ]; then \
+			echo "Expected artifact $$ARTIFACT to be created." >&2; \
+			exit 1; \
+		fi; \
+	else \
+		cat "$$LOG"; \
+		exit 1; \
+	fi
 
 1c-dump-txt:
 	@mkdir -p "$(ONEC_LOG_DIR)"

--- a/docs/runbooks/ww.md
+++ b/docs/runbooks/ww.md
@@ -71,7 +71,7 @@
 - Телефоны выводим шаблоном `+7***-***-XX-XX`; email — `f***@domain`; суммы клиентов — `****.**`.
 - Скрипт `scripts/check_pii_mask.py` (при появлении) должен запускаться в CI перед релизом.
 - При нарушении маскировки:
-  1. Немедленно отключить экспорт логов в внешние системы (`make logs-stop-forward`).
+  1. Немедленно отключить экспорт логов во внешние системы: масштабируйте агент, который шлёт логи в Loki (`kubectl scale daemonset loki-promtail -n observability --replicas=0`) и убедитесь, что поды остановлены (`kubectl get pods -n observability -l app.kubernetes.io/name=promtail`).
   2. Заэскалировать в `#security` и владельцам Walking Warehouse.
   3. Вырезать инцидентные записи (через `loki-adm tail --delete --ids ...`), задокументировать в postmortem.
 


### PR DESCRIPTION
## Summary
- replace the obsolete `make logs-stop-forward` reference in the Walking Warehouse runbook with the kubectl steps that disable the Loki log forwarder
- fix the indentation of the `1c-pack-kmp4` recipe in the Makefile so `make docs-ci` parses correctly

## Testing
- make docs-ci *(fails: docker is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dffa5c6a6c832a8776277640d256d4