### PR TITLE
docs: sync assistant master docs with 00-core v1.3.4

### DIFF
--- a/docs/ONE-PAGER — Ассистент мастера v0.1.md
+++ b/docs/ONE-PAGER — Ассистент мастера v0.1.md
@@ -1,5 +1,6 @@
 ONE-PAGER — Ассистент мастера v0.1 («две головы»)
 Версия: 0.1 • Дата: 30.09.2025
+Синхронизировано с 00‑Core v1.3.4 (Core‑API‑Style, Status‑Dictionary, SoT‑Matrix).
 
 🎯 Цель
 

--- a/docs/PRD — «Ассистент мастера».md
+++ b/docs/PRD — «Ассистент мастера».md
@@ -1,7 +1,9 @@
 PRD — «Ассистент мастера» v0.1 (интеграция через сайт, готово к запуску)
 Версия: 0.1.1 (Final) • Дата: 30.09.2025
 Владелец продукта: {имя/контакт} • Техлид (бот): {имя/контакт} • Техлид (сайт/API): {имя/контакт}
-Ссылки на 00‑Core v1.3.3: [§2 Core‑API‑Style](00%E2%80%91Core%20%E2%80%94%20%D0%A1%D0%B8%D0%BD%D1%85%D1%80%D0%BE%D0%BD%D0%B8%D0%B7%D0%B0%D1%86%D0%B8%D1%8F%20%D0%B4%D0%BE%D0%BA%D1%83%D0%BC%D0%B5%D0%BD%D1%82%D0%B0%D1%86%D0%B8%D0%B8.md#2-core-api-style-v1), [§3 Status‑Dictionary](00%E2%80%91Core%20%E2%80%94%20%D0%A1%D0%B8%D0%BD%D1%85%D1%80%D0%BE%D0%BD%D0%B8%D0%B7%D0%B0%D1%86%D0%B8%D1%8F%20%D0%B4%D0%BE%D0%BA%D1%83%D0%BC%D0%B5%D0%BD%D1%82%D0%B0%D1%86%D0%B8%D0%B8.md#3-status-dictionary-v1), [§5 SoT‑Matrix](00%E2%80%91Core%20%E2%80%94%20%D0%A1%D0%B8%D0%BD%D1%85%D1%80%D0%BE%D0%BD%D0%B8%D0%B7%D0%B0%D1%86%D0%B8%D1%8F%20%D0%B4%D0%BE%D0%BA%D1%83%D0%BC%D0%B5%D0%BD%D1%82%D0%B0%D1%86%D0%B8%D0%B8.md#5-sot-matrix-v1-source-of-truth).
+Ссылки на 00‑Core v1.3.4: [§2 Core‑API‑Style](00%E2%80%91Core%20%E2%80%94%20%D0%A1%D0%B8%D0%BD%D1%85%D1%80%D0%BE%D0%BD%D0%B8%D0%B7%D0%B0%D1%86%D0%B8%D1%8F%20%D0%B4%D0%BE%D0%BA%D1%83%D0%BC%D0%B5%D0%BD%D1%82%D0%B0%D1%86%D0%B8%D0%B8.md#2-core-api-style-v1), [§3 Status‑Dictionary](00%E2%80%91Core%20%E2%80%94%20%D0%A1%D0%B8%D0%BD%D1%85%D1%80%D0%BE%D0%BD%D0%B8%D0%B7%D0%B0%D1%86%D0%B8%D1%8F%20%D0%B4%D0%BE%D0%BA%D1%83%D0%BC%D0%B5%D0%BD%D1%82%D0%B0%D1%86%D0%B8%D0%B8.md#3-status-dictionary-v1), [§5 SoT‑Matrix](00%E2%80%91Core%20%E2%80%94%20%D0%A1%D0%B8%D0%BD%D1%85%D1%80%D0%BE%D0%BD%D0%B8%D0%B7%D0%B0%D1%86%D0%B8%D1%8F%20%D0%B4%D0%BE%D0%BA%D1%83%D0%BC%D0%B5%D0%BD%D1%82%D0%B0%D1%86%D0%B8%D0%B8.md#5-sot-matrix-v1-source-of-truth).
+
+> Changelog 30.09.2025: обновлена привязка к 00‑Core v1.3.4 согласно актуальному Version Map.
 
 ## 1. Обзор и цели
 Telegram-бот (голос/текст) для B2B-мастеров: быстрый поиск запчастей, оформление заказов (prepaid и COD/«Неси»), статусы/трекинг, возвраты (RMA), короткие техподсказки.


### PR DESCRIPTION
## Summary
- обновил ссылки в PRD «Ассистент мастера» на 00‑Core v1.3.4 и добавил changelog
- отметил в ONE-PAGER синхронизацию с 00‑Core v1.3.4 для согласованности артефактов

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e00409bc90832ab4603e94614474c3